### PR TITLE
Fix compilation by renaming a class usage

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RCTWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RCTWebViewManager.java
@@ -652,7 +652,7 @@ public class RCTWebViewManager extends SimpleViewManager<WebView> {
         break;
       case COMMAND_POST_MESSAGE:
         try {
-          ReactWebView reactWebView = (ReactWebView) root;
+          RCTWebView reactWebView = (RCTWebView) root;
           JSONObject eventInitDict = new JSONObject();
           eventInitDict.put("data", args.getString(0));
           reactWebView.evaluateJavascriptWithFallback("(function () {" +
@@ -671,7 +671,7 @@ public class RCTWebViewManager extends SimpleViewManager<WebView> {
         }
         break;
       case COMMAND_INJECT_JAVASCRIPT:
-        ReactWebView reactWebView = (ReactWebView) root;
+        RCTWebView reactWebView = (RCTWebView) root;
         reactWebView.evaluateJavascriptWithFallback(args.getString(0));
         break;
     }


### PR DESCRIPTION
This is not usable currently because it does not compile for android. I need this because of this issue right now: https://github.com/facebook/react-native/issues/21104

Compiling for mac still does not work.