### PR TITLE
Migrate Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * [x] Android
 * [ ] Windows 10 (coming soon)
 
-## Installation
+## Getting Started
 
 *Note: this is currently a work-in-progress and not yet published to NPM.*
 
@@ -18,6 +18,8 @@
 $ npm install --save https://github.com/react-native-community/react-native-webview
 $ react-native link react-native-webview
 ```
+
+Read our [Getting Started Guide](./docs/Getting-Started.md) for more.
 
 ## Usage
 
@@ -41,9 +43,7 @@ class MyWebComponent extends Component {
 }
 ```
 
-Additional properties are supported and will be added here; for now, refer to the previous React Native WebView documentation for more.
-
-[https://facebook.github.io/react-native/docs/webview](https://facebook.github.io/react-native/docs/webview)
+For more, read the [API Reference](./docs/Reference.md) and [Guide](./docs/Guide.md).
 
 ## Migrate from React Native core WebView to React Native WebView
 

--- a/docs/Custom-Android.md
+++ b/docs/Custom-Android.md
@@ -1,0 +1,255 @@
+**NOTE: This document was imported from [the original WebView documentation](https://github.com/facebook/react-native-website/blob/7d3e9e120e38a7ba928f6b173eb98f88b6f2f85f/docs/custom-webview-android.md). While it may prove useful, it has not been adapted to React Native WebView yet.**
+
+While the built-in web view has a lot of features, it is not possible to handle every use-case in React Native. You can, however, extend the web view with native code without forking React Native or duplicating all the existing web view code.
+
+Before you do this, you should be familiar with the concepts in [native UI components](native-components-android). You should also familiarise yourself with the [native code for web views](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java), as you will have to use this as a reference when implementing new features—although a deep understanding is not required.
+
+## Native Code
+
+To get started, you'll need to create a subclass of `ReactWebViewManager`, `ReactWebView`, and `ReactWebViewClient`. In your view manager, you'll then need to override:
+
+* `createReactWebViewInstance`
+* `getName`
+* `addEventEmitters`
+
+```java
+@ReactModule(name = CustomWebViewManager.REACT_CLASS)
+public class CustomWebViewManager extends ReactWebViewManager {
+  /* This name must match what we're referring to in JS */
+  protected static final String REACT_CLASS = "RCTCustomWebView";
+
+  protected static class CustomWebViewClient extends ReactWebViewClient { }
+
+  protected static class CustomWebView extends ReactWebView {
+    public CustomWebView(ThemedReactContext reactContext) {
+      super(reactContext);
+    }
+  }
+
+  @Override
+  protected ReactWebView createReactWebViewInstance(ThemedReactContext reactContext) {
+    return new CustomWebView(reactContext);
+  }
+
+  @Override
+  public String getName() {
+    return REACT_CLASS;
+  }
+
+  @Override
+  protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
+    view.setWebViewClient(new CustomWebViewClient());
+  }
+}
+```
+
+You'll need to follow the usual steps to [register the module](native-modules-android.md#register-the-module).
+
+### Adding New Properties
+
+To add a new property, you'll need to add it to `CustomWebView`, and then expose it in `CustomWebViewManager`.
+
+```java
+public class CustomWebViewManager extends ReactWebViewManager {
+  ...
+
+  protected static class CustomWebView extends ReactWebView {
+    public CustomWebView(ThemedReactContext reactContext) {
+      super(reactContext);
+    }
+
+    protected @Nullable String mFinalUrl;
+
+    public void setFinalUrl(String url) {
+        mFinalUrl = url;
+    }
+
+    public String getFinalUrl() {
+        return mFinalUrl;
+    }
+  }
+
+  ...
+
+  @ReactProp(name = "finalUrl")
+  public void setFinalUrl(WebView view, String url) {
+    ((CustomWebView) view).setFinalUrl(url);
+  }
+}
+```
+
+### Adding New Events
+
+For events, you'll first need to make create event subclass.
+
+```java
+// NavigationCompletedEvent.java
+public class NavigationCompletedEvent extends Event<NavigationCompletedEvent> {
+  private WritableMap mParams;
+
+  public NavigationCompletedEvent(int viewTag, WritableMap params) {
+    super(viewTag);
+    this.mParams = params;
+  }
+
+  @Override
+  public String getEventName() {
+    return "navigationCompleted";
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    init(getViewTag());
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), mParams);
+  }
+}
+```
+
+You can trigger the event in your web view client. You can hook existing handlers if your events are based on them.
+
+You should refer to [ReactWebViewManager.java](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java) in the React Native codebase to see what handlers are available and how they are implemented. You can extend any methods here to provide extra functionality.
+
+```java
+public class NavigationCompletedEvent extends Event<NavigationCompletedEvent> {
+  private WritableMap mParams;
+
+  public NavigationCompletedEvent(int viewTag, WritableMap params) {
+    super(viewTag);
+    this.mParams = params;
+  }
+
+  @Override
+  public String getEventName() {
+    return "navigationCompleted";
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    init(getViewTag());
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), mParams);
+  }
+}
+
+// CustomWebViewManager.java
+protected static class CustomWebViewClient extends ReactWebViewClient {
+  @Override
+  public boolean shouldOverrideUrlLoading(WebView view, String url) {
+    boolean shouldOverride = super.shouldOverrideUrlLoading(view, url);
+    String finalUrl = ((CustomWebView) view).getFinalUrl();
+
+    if (!shouldOverride && url != null && finalUrl != null && new String(url).equals(finalUrl)) {
+      final WritableMap params = Arguments.createMap();
+      dispatchEvent(view, new NavigationCompletedEvent(view.getId(), params));
+    }
+
+    return shouldOverride;
+  }
+}
+```
+
+Finally, you'll need to expose the events in `CustomWebViewManager` through `getExportedCustomDirectEventTypeConstants`. Note that currently, the default implementation returns `null`, but this may change in the future.
+
+```java
+public class CustomWebViewManager extends ReactWebViewManager {
+  ...
+
+  @Override
+  public @Nullable
+  Map getExportedCustomDirectEventTypeConstants() {
+    Map<String, Object> export = super.getExportedCustomDirectEventTypeConstants();
+    if (export == null) {
+      export = MapBuilder.newHashMap();
+    }
+    export.put("navigationCompleted", MapBuilder.of("registrationName", "onNavigationCompleted"));
+    return export;
+  }
+}
+```
+
+## JavaScript Interface
+
+To use your custom web view, you'll need to create a class for it. Your class must:
+
+* Export all the prop types from `WebView.propTypes`
+* Return a `WebView` component with the prop `nativeConfig.component` set to your native component (see below)
+
+To get your native component, you must use `requireNativeComponent`: the same as for regular custom components. However, you must pass in an extra third argument, `WebView.extraNativeComponentConfig`. This third argument contains prop types that are only required for native code.
+
+```javascript
+import React, {Component, PropTypes} from 'react';
+import {WebView, requireNativeComponent} from 'react-native';
+
+export default class CustomWebView extends Component {
+  static propTypes = WebView.propTypes;
+
+  render() {
+    return (
+      <WebView {...this.props} nativeConfig={{component: RCTCustomWebView}} />
+    );
+  }
+}
+
+const RCTCustomWebView = requireNativeComponent(
+  'RCTCustomWebView',
+  CustomWebView,
+  WebView.extraNativeComponentConfig
+);
+```
+
+If you want to add custom props to your native component, you can use `nativeConfig.props` on the web view.
+
+For events, the event handler must always be set to a function. This means it isn't safe to use the event handler directly from `this.props`, as the user might not have provided one. The standard approach is to create a event handler in your class, and then invoking the event handler given in `this.props` if it exists.
+
+If you are unsure how something should be implemented from the JS side, look at [WebView.android.js](https://github.com/facebook/react-native/blob/master/Libraries/Components/WebView/WebView.android.js) in the React Native source.
+
+```javascript
+export default class CustomWebView extends Component {
+  static propTypes = {
+    ...WebView.propTypes,
+    finalUrl: PropTypes.string,
+    onNavigationCompleted: PropTypes.func,
+  };
+
+  static defaultProps = {
+    finalUrl: 'about:blank',
+  };
+
+  _onNavigationCompleted = (event) => {
+    const {onNavigationCompleted} = this.props;
+    onNavigationCompleted && onNavigationCompleted(event);
+  };
+
+  render() {
+    return (
+      <WebView
+        {...this.props}
+        nativeConfig={{
+          component: RCTCustomWebView,
+          props: {
+            finalUrl: this.props.finalUrl,
+            onNavigationCompleted: this._onNavigationCompleted,
+          },
+        }}
+      />
+    );
+  }
+}
+```
+
+Just like for regular native components, you must provide all your prop types in the component to have them forwarded on to the native component. However, if you have some prop types that are only used internally in component, you can add them to the `nativeOnly` property of the third argument previously mentioned. For event handlers, you have to use the value `true` instead of a regular prop type.
+
+For example, if you wanted to add an internal event handler called `onScrollToBottom`, you would use,
+
+```javascript
+const RCTCustomWebView = requireNativeComponent(
+  'RCTCustomWebView',
+  CustomWebView,
+  {
+    ...WebView.extraNativeComponentConfig,
+    nativeOnly: {
+      ...WebView.extraNativeComponentConfig.nativeOnly,
+      onScrollToBottom: true,
+    },
+  }
+);
+```

--- a/docs/Custom-iOS.md
+++ b/docs/Custom-iOS.md
@@ -1,0 +1,229 @@
+**NOTE: This document was imported from [the original WebView documentation](https://github.com/facebook/react-native-website/blob/7d3e9e120e38a7ba928f6b173eb98f88b6f2f85f/docs/custom-webview-ios.md). While it may prove useful, it has not been adapted to React Native WebView yet.**
+
+While the built-in web view has a lot of features, it is not possible to handle every use-case in React Native. You can, however, extend the web view with native code without forking React Native or duplicating all the existing web view code.
+
+Before you do this, you should be familiar with the concepts in [native UI components](native-components-ios). You should also familiarise yourself with the [native code for web views](https://github.com/facebook/react-native/blob/master/React/Views/RCTWebViewManager.m), as you will have to use this as a reference when implementing new features—although a deep understanding is not required.
+
+## Native Code
+
+Like for regular native components, you need a view manager and an web view.
+
+For the view, you'll need to make a subclass of `RCTWebView`.
+
+```objc
+// RCTCustomWebView.h
+#import <React/RCTWebView.h>
+
+@interface RCTCustomWebView : RCTWebView
+
+@end
+
+// RCTCustomWebView.m
+#import "RCTCustomWebView.h"
+
+@interface RCTCustomWebView ()
+
+@end
+
+@implementation RCTCustomWebView { }
+
+@end
+```
+
+For the view manager, you need to make a subclass `RCTWebViewManager`. You must still include:
+
+* `(UIView *)view` that returns your custom view
+* The `RCT_EXPORT_MODULE()` tag
+
+```objc
+// RCTCustomWebViewManager.h
+#import <React/RCTWebViewManager.h>
+
+@interface RCTCustomWebViewManager : RCTWebViewManager
+
+@end
+
+// RCTCustomWebViewManager.m
+#import "RCTCustomWebViewManager.h"
+#import "RCTCustomWebView.h"
+
+@interface RCTCustomWebViewManager () <RCTWebViewDelegate>
+
+@end
+
+@implementation RCTCustomWebViewManager { }
+
+RCT_EXPORT_MODULE()
+
+- (UIView *)view
+{
+  RCTCustomWebView *webView = [RCTCustomWebView new];
+  webView.delegate = self;
+  return webView;
+}
+
+@end
+```
+
+### Adding New Events and Properties
+
+Adding new properties and events is the same as regular UI components. For properties, you define an `@property` in the header. For events, you define a `RCTDirectEventBlock` in the view's `@interface`.
+
+```objc
+// RCTCustomWebView.h
+@property (nonatomic, copy) NSString *finalUrl;
+
+// RCTCustomWebView.m
+@interface RCTCustomWebView ()
+
+@property (nonatomic, copy) RCTDirectEventBlock onNavigationCompleted;
+
+@end
+```
+
+Then expose it in the view manager's `@implementation`.
+
+```objc
+// RCTCustomWebViewManager.m
+RCT_EXPORT_VIEW_PROPERTY(onNavigationCompleted, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(finalUrl, NSString)
+```
+
+### Extending Existing Events
+
+You should refer to [RCTWebView.m](https://github.com/facebook/react-native/blob/master/React/Views/RCTWebView.m) in the React Native codebase to see what handlers are available and how they are implemented. You can extend any methods here to provide extra functionality.
+
+By default, most methods aren't exposed from RCTWebView. If you need to expose them, you need to create an [Objective C category](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html), and then expose all the methods you need to use.
+
+```objc
+// RCTWebView+Custom.h
+#import <React/RCTWebView.h>
+
+@interface RCTWebView (Custom)
+- (BOOL)webView:(__unused UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType;
+- (NSMutableDictionary<NSString *, id> *)baseEvent;
+@end
+```
+
+Once these are exposed, you can reference them in your custom web view class.
+
+```objc
+// RCTCustomWebView.m
+
+// Remember to import the category file.
+#import "RCTWebView+Custom.h"
+
+- (BOOL)webView:(__unused UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request
+ navigationType:(UIWebViewNavigationType)navigationType
+{
+  BOOL allowed = [super webView:webView shouldStartLoadWithRequest:request navigationType:navigationType];
+
+  if (allowed) {
+    NSString* url = request.URL.absoluteString;
+    if (url && [url isEqualToString:_finalUrl]) {
+      if (_onNavigationCompleted) {
+        NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+        _onNavigationCompleted(event);
+      }
+    }
+  }
+
+  return allowed;
+}
+```
+
+## JavaScript Interface
+
+To use your custom web view, you'll need to create a class for it. Your class must:
+
+* Export all the prop types from `WebView.propTypes`
+* Return a `WebView` component with the prop `nativeConfig.component` set to your native component (see below)
+
+To get your native component, you must use `requireNativeComponent`: the same as for regular custom components. However, you must pass in an extra third argument, `WebView.extraNativeComponentConfig`. This third argument contains prop types that are only required for native code.
+
+```javascript
+import React, {Component, PropTypes} from 'react';
+import {WebView, requireNativeComponent, NativeModules} from 'react-native';
+const {CustomWebViewManager} = NativeModules;
+
+export default class CustomWebView extends Component {
+  static propTypes = WebView.propTypes;
+
+  render() {
+    return (
+      <WebView
+        {...this.props}
+        nativeConfig={{
+          component: RCTCustomWebView,
+          viewManager: CustomWebViewManager,
+        }}
+      />
+    );
+  }
+}
+
+const RCTCustomWebView = requireNativeComponent(
+  'RCTCustomWebView',
+  CustomWebView,
+  WebView.extraNativeComponentConfig
+);
+```
+
+If you want to add custom props to your native component, you can use `nativeConfig.props` on the web view. For iOS, you should also set the `nativeConfig.viewManager` prop with your custom WebView ViewManager as in the example above.
+
+For events, the event handler must always be set to a function. This means it isn't safe to use the event handler directly from `this.props`, as the user might not have provided one. The standard approach is to create a event handler in your class, and then invoking the event handler given in `this.props` if it exists.
+
+If you are unsure how something should be implemented from the JS side, look at [WebView.ios.js](https://github.com/facebook/react-native/blob/master/Libraries/Components/WebView/WebView.ios.js) in the React Native source.
+
+```javascript
+export default class CustomWebView extends Component {
+  static propTypes = {
+    ...WebView.propTypes,
+    finalUrl: PropTypes.string,
+    onNavigationCompleted: PropTypes.func,
+  };
+
+  static defaultProps = {
+    finalUrl: 'about:blank',
+  };
+
+  _onNavigationCompleted = (event) => {
+    const {onNavigationCompleted} = this.props;
+    onNavigationCompleted && onNavigationCompleted(event);
+  };
+
+  render() {
+    return (
+      <WebView
+        {...this.props}
+        nativeConfig={{
+          component: RCTCustomWebView,
+          props: {
+            finalUrl: this.props.finalUrl,
+            onNavigationCompleted: this._onNavigationCompleted,
+          },
+          viewManager: CustomWebViewManager,
+        }}
+      />
+    );
+  }
+}
+```
+
+Just like for regular native components, you must provide all your prop types in the component to have them forwarded on to the native component. However, if you have some prop types that are only used internally in component, you can add them to the `nativeOnly` property of the third argument previously mentioned. For event handlers, you have to use the value `true` instead of a regular prop type.
+
+For example, if you wanted to add an internal event handler called `onScrollToBottom`, you would use,
+
+```javascript
+const RCTCustomWebView = requireNativeComponent(
+  'RCTCustomWebView',
+  CustomWebView,
+  {
+    ...WebView.extraNativeComponentConfig,
+    nativeOnly: {
+      ...WebView.extraNativeComponentConfig.nativeOnly,
+      onScrollToBottom: true,
+    },
+  }
+);
+```

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,0 +1,59 @@
+# React Native WebView Getting Started Guide
+
+Here's how to get started quickly with the React Native WebView.
+
+#### 1. Add react-native-webview to your dependencies
+
+```
+$ npm install --save https://github.com/react-native-community/react-native-webview
+```
+
+#### 2. Link native dependencies
+
+React Native modules that include native Objective-C, Swift, Java, or Kotlin code have to be "linked" so that the compiler knows to include them in the app.
+
+Thankfully, there's a way to do this from the terminal with one command:
+
+```
+$ react-native link react-native-webview
+```
+
+_NOTE: If you ever need to uninstall React Native WebView, run `react-native unlink react-native-webview` to unlink it._
+
+#### 3. Import the webview into your component
+
+```js
+import React, { Component } from 'react';
+import { WebView } from 'react-native-webview';
+
+class MyWeb extends Component {
+  render() {
+    return (
+      <WebView
+        source={{uri: 'https://infinite.red'}}
+        style={{marginTop: 20}}
+      />
+    );
+  }
+}
+```
+
+Minimal example with inline HTML:
+
+```js
+import React, { Component } from 'react';
+import { WebView } from 'react-native-webview';
+
+class MyInlineWeb extends Component {
+  render() {
+    return (
+      <WebView
+        originWhitelist={['*']}
+        source={{ html: '<h1>Hello world</h1>' }}
+      />
+    );
+  }
+}
+```
+
+Next, check out the [API Reference](Reference.md) or [In-Depth Guide](Guide.md).

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -1,5 +1,52 @@
 # React Native WebView Guide
 
-This document walks you through the most common use cases for React Native WebView. It doesn't cover [the full API](Reference.md), but after reading it you should have a good sense for how the WebView works and common patterns for using the WebView.
+This document walks you through the most common use cases for React Native WebView. It doesn't cover [the full API](Reference.md), but after reading it and looking at the sample code snippets you should have a good sense for how the WebView works and common patterns for using the WebView.
 
-_Coming soon!_
+_This guide is currently a work in progress._
+
+## Guide Index
+
+- [Basic Inline HTML](Guide.md#basic-inline-html)
+- [Basic URL Source](Guide.md#basic-url-source)
+
+### Basic inline HTML
+
+The simplest way to use the WebView is to simply pipe in the HTML you want to display. Note that setting an `html` source requires the [originWhiteList](Reference.md#originWhiteList) property to be set to `['*']`.
+
+```js
+import React, { Component } from 'react';
+import { WebView } from 'react-native-webview';
+
+class MyInlineWeb extends Component {
+  render() {
+    return (
+      <WebView
+        originWhitelist={['*']}
+        source={{ html: '<h1>This is a static HTML source!</h1>' }}
+      />
+    );
+  }
+}
+```
+
+Passing a new static html source will cause the WebView to rerender.
+
+### Basic URL Source
+
+This is the most common use-case for WebView.
+
+```js
+import React, { Component } from 'react';
+import { WebView } from 'react-native-webview';
+
+class MyWeb extends Component {
+  render() {
+    return (
+      <WebView
+        source={{uri: 'https://infinite.red/react-native'}}
+      />
+    );
+  }
+}
+```
+

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -1,0 +1,5 @@
+# React Native WebView Guide
+
+This document walks you through the most common use cases for React Native WebView. It doesn't cover [the full API](Reference.md), but after reading it you should have a good sense for how the WebView works and common patterns for using the WebView.
+
+_Coming soon!_

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -71,6 +71,8 @@ The object passed to `source` can have either of the following shapes:
 
 **Static HTML**
 
+_Note that using static HTML requires the WebView property [originWhiteList](Reference.md#originWhiteList) to `['*']`._
+
 * `html` (string) - A static HTML page to display in the WebView.
 * `baseUrl` (string) - The base URL to be used for any relative links in the HTML.
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1,0 +1,493 @@
+# React Native WebView API Reference
+
+This document lays out the current public properties and methods for the React Native WebView.
+
+> **Security Warning:** Currently, `onMessage` and `postMessage` do not allow specifying an origin. This can lead to cross-site scripting attacks if an unexpected document is loaded within a `WebView` instance. Please refer to the MDN documentation for [`Window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) for more details on the security implications of this.
+
+## Props Index
+
+- [`source`](Reference.md#source)
+- [`automaticallyAdjustContentInsets`](Reference.md#automaticallyadjustcontentinsets)
+- [`injectJavaScript`](Reference.md#injectjavascript)
+- [`injectedJavaScript`](Reference.md#injectedjavascript)
+- [`mediaPlaybackRequiresUserAction`](Reference.md#mediaplaybackrequiresuseraction)
+- [`nativeConfig`](Reference.md#nativeconfig)
+- [`onError`](Reference.md#onerror)
+- [`onLoad`](Reference.md#onload)
+- [`onLoadEnd`](Reference.md#onloadend)
+- [`onLoadStart`](Reference.md#onloadstart)
+- [`onMessage`](Reference.md#onmessage)
+- [`onNavigationStateChange`](Reference.md#onnavigationstatechange)
+- [`originWhitelist`](Reference.md#originwhitelist)
+- [`renderError`](Reference.md#rendererror)
+- [`renderLoading`](Reference.md#renderloading)
+- [`scalesPageToFit`](Reference.md#scalespagetofit)
+- [`onShouldStartLoadWithRequest`](Reference.md#onshouldstartloadwithrequest)
+- [`startInLoadingState`](Reference.md#startinloadingstate)
+- [`style`](Reference.md#style)
+- [`decelerationRate`](Reference.md#decelerationrate)
+- [`domStorageEnabled`](Reference.md#domstorageenabled)
+- [`javaScriptEnabled`](Reference.md#javascriptenabled)
+- [`mixedContentMode`](Reference.md#mixedcontentmode)
+- [`thirdPartyCookiesEnabled`](Reference.md#thirdpartycookiesenabled)
+- [`userAgent`](Reference.md#useragent)
+- [`allowsInlineMediaPlayback`](Reference.md#allowsinlinemediaplayback)
+- [`bounces`](Reference.md#bounces)
+- [`contentInset`](Reference.md#contentinset)
+- [`dataDetectorTypes`](Reference.md#datadetectortypes)
+- [`scrollEnabled`](Reference.md#scrollenabled)
+- [`geolocationEnabled`](Reference.md#geolocationenabled)
+- [`allowUniversalAccessFromFileURLs`](Reference.md#allowUniversalAccessFromFileURLs)
+- [`useWebKit`](Reference.md#usewebkit)
+- [`url`](Reference.md#url)
+- [`html`](Reference.md#html)
+
+## Methods Index
+
+* [`extraNativeComponentConfig`](Reference.md#extranativecomponentconfig)
+* [`goForward`](Reference.md#goforward)
+* [`goBack`](Reference.md#goback)
+* [`reload`](Reference.md#reload)
+* [`stopLoading`](Reference.md#stoploading)
+
+---
+
+# Reference
+
+## Props
+
+### `source`
+
+Loads static HTML or a URI (with optional headers) in the WebView. Note that static HTML will require setting [`originWhitelist`](Reference.md#originwhitelist) to `["*"]`.
+
+The object passed to `source` can have either of the following shapes:
+
+**Load uri**
+
+* `uri` (string) - The URI to load in the `WebView`. Can be a local or remote file.
+* `method` (string) - The HTTP Method to use. Defaults to GET if not specified. On Android, the only supported methods are GET and POST.
+* `headers` (object) - Additional HTTP headers to send with the request. On Android, this can only be used with GET requests.
+* `body` (string) - The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. On Android, this can only be used with POST requests.
+
+**Static HTML**
+
+* `html` (string) - A static HTML page to display in the WebView.
+* `baseUrl` (string) - The base URL to be used for any relative links in the HTML.
+
+| Type   | Required |
+| ------ | -------- |
+| object | No       |
+
+---
+
+### `automaticallyAdjustContentInsets`
+
+Controls whether to adjust the content inset for web views that are placed behind a navigation bar, tab bar, or toolbar. The default value is `true`.
+
+| Type | Required |
+| ---- | -------- |
+| bool | No       |
+
+---
+
+### `injectJavaScript`
+
+Function that accepts a string that will be passed to the WebView and executed immediately as JavaScript.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `injectedJavaScript`
+
+Set this to provide JavaScript that will be injected into the web page when the view loads.
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
+
+---
+
+### `mediaPlaybackRequiresUserAction`
+
+Boolean that determines whether HTML5 audio and video requires the user to tap them before they start playing. The default value is `true`.
+
+| Type | Required |
+| ---- | -------- |
+| bool | No       |
+
+---
+
+### `nativeConfig`
+
+Override the native component used to render the WebView. Enables a custom native WebView which uses the same JavaScript as the original WebView.
+
+The `nativeConfig` prop expects an object with the following keys:
+
+* `component` (any)
+* `props` (object)
+* `viewManager` (object)
+
+| Type   | Required |
+| ------ | -------- |
+| object | No       |
+
+---
+
+### `onError`
+
+Function that is invoked when the `WebView` load fails.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `onLoad`
+
+Function that is invoked when the `WebView` has finished loading.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `onLoadEnd`
+
+Function that is invoked when the `WebView` load succeeds or fails.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `onLoadStart`
+
+Function that is invoked when the `WebView` starts loading.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `onMessage`
+
+A function that is invoked when the webview calls `window.postMessage`. Setting this property will inject a `postMessage` global into your webview, but will still call pre-existing values of `postMessage`.
+
+`window.postMessage` accepts one argument, `data`, which will be available on the event object, `event.nativeEvent.data`. `data` must be a string.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `onNavigationStateChange`
+
+Function that is invoked when the `WebView` loading starts or ends.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `originWhitelist`
+
+List of origin strings to allow being navigated to. The strings allow wildcards and get matched against _just_ the origin (not the full URL). If the user taps to navigate to a new page but the new page is not in this whitelist, the URL will be handled by the OS. The default whitelisted origins are "http://*" and "https://*".
+
+| Type             | Required |
+| ---------------- | -------- |
+| array of strings | No       |
+
+---
+
+### `renderError`
+
+Function that returns a view to show if there's an error.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `renderLoading`
+
+Function that returns a loading indicator. The startInLoadingState prop must be set to true in order to use this prop.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `scalesPageToFit`
+
+Boolean that controls whether the web content is scaled to fit the view and enables the user to change the scale. The default value is `true`.
+
+On iOS, when [`useWebKit=true`](Reference.md#usewebkit), this prop will not work.
+
+| Type | Required |
+| ---- | -------- |
+| bool | No       |
+
+---
+
+### `onShouldStartLoadWithRequest`
+
+Function that allows custom handling of any web view requests. Return `true` from the function to continue loading the request and `false` to stop loading.
+
+| Type     | Required | Platform |
+| -------- | -------- | -------- |
+| function | No       | iOS      |
+
+---
+
+### `startInLoadingState`
+
+Boolean value that forces the `WebView` to show the loading view on the first load. This prop must be set to `true` in order for the `renderLoading` prop to work.
+
+| Type | Required |
+| ---- | -------- |
+| bool | No       |
+
+---
+
+### `decelerationRate`
+
+A floating-point number that determines how quickly the scroll view decelerates after the user lifts their finger. You may also use the string shortcuts `"normal"` and `"fast"` which match the underlying iOS settings for `UIScrollViewDecelerationRateNormal` and `UIScrollViewDecelerationRateFast` respectively:
+
+* normal: 0.998
+* fast: 0.99 (the default for iOS web view)
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | iOS      |
+
+---
+
+### `domStorageEnabled`
+
+Boolean value to control whether DOM Storage is enabled. Used only in Android.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android  |
+
+---
+
+### `javaScriptEnabled`
+
+Boolean value to enable JavaScript in the `WebView`. Used on Android only as JavaScript is enabled by default on iOS. The default value is `true`.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android  |
+
+---
+
+### `mixedContentMode`
+
+Specifies the mixed content mode. i.e WebView will allow a secure origin to load content from any other origin.
+
+Possible values for `mixedContentMode` are:
+
+* `never` (default) - WebView will not allow a secure origin to load content from an insecure origin.
+* `always` - WebView will allow a secure origin to load content from any other origin, even if that origin is insecure.
+* `compatibility` - WebView will attempt to be compatible with the approach of a modern web browser with regard to mixed content.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | Android  |
+
+---
+
+### `thirdPartyCookiesEnabled`
+
+Boolean value to enable third party cookies in the `WebView`. Used on Android Lollipop and above only as third party cookies are enabled by default on Android Kitkat and below and on iOS. The default value is `true`.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android  |
+
+---
+
+### `userAgent`
+
+Sets the user-agent for the `WebView`.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | Android  |
+
+---
+
+### `allowsInlineMediaPlayback`
+
+Boolean that determines whether HTML5 videos play inline or use the native full-screen controller. The default value is `false`.
+
+> **NOTE**
+>
+> In order for video to play inline, not only does this property need to be set to `true`, but the video element in the HTML document must also include the `webkit-playsinline` attribute.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | iOS      |
+
+---
+
+### `bounces`
+
+Boolean value that determines whether the web view bounces when it reaches the edge of the content. The default value is `true`.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | iOS      |
+
+---
+
+### `contentInset`
+
+The amount by which the web view content is inset from the edges of the scroll view. Defaults to {top: 0, left: 0, bottom: 0, right: 0}.
+
+| Type                                                               | Required | Platform |
+| ------------------------------------------------------------------ | -------- | -------- |
+| object: {top: number, left: number, bottom: number, right: number} | No       | iOS      |
+
+---
+
+### `dataDetectorTypes`
+
+Determines the types of data converted to clickable URLs in the web view's content. By default only phone numbers are detected.
+
+You can provide one type or an array of many types.
+
+Possible values for `dataDetectorTypes` are:
+
+* `phoneNumber`
+* `link`
+* `address`
+* `calendarEvent`
+* `none`
+* `all`
+
+With the [new WebKit](Reference.md#usewebkit) implementation, we have three new values:
+
+* `trackingNumber`
+* `flightNumber`
+* `lookupSuggestion`
+
+| Type             | Required | Platform |
+| ---------------- | -------- | -------- |
+| string, or array | No       | iOS      |
+
+---
+
+### `scrollEnabled`
+
+Boolean value that determines whether scrolling is enabled in the `WebView`. The default value is `true`.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | iOS      |
+
+---
+
+### `geolocationEnabled`
+
+Set whether Geolocation is enabled in the `WebView`. The default value is `false`. Used only in Android.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android  |
+
+---
+
+### `allowUniversalAccessFromFileURLs`
+
+Boolean that sets whether JavaScript running in the context of a file scheme URL should be allowed to access content from any origin. Including accessing content from other file scheme URLs. The default value is `false`.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android  |
+
+---
+
+### `useWebKit`
+
+If true, use WKWebView instead of UIWebView.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
+
+---
+
+### `url`
+
+**Deprecated.** Use the `source` prop instead.
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
+
+---
+
+### `html`
+
+**Deprecated.** Use the `source` prop instead.
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
+
+## Methods
+
+### `extraNativeComponentConfig()`
+
+```javascript
+static extraNativeComponentConfig()
+```
+
+### `goForward()`
+
+```javascript
+goForward();
+```
+
+Go forward one page in the web view's history.
+
+### `goBack()`
+
+```javascript
+goBack();
+```
+
+Go back one page in the web view's history.
+
+### `reload()`
+
+```javascript
+reload();
+```
+
+Reloads the current page.
+
+### `stopLoading()`
+
+```javascript
+stopLoading();
+```
+
+Stop loading the current page.
+
+## Other Docs
+
+Also check out our [Getting Started Guide](Getting-Started.md) and [In-Depth Guide](Guide.md).


### PR DESCRIPTION
This migrates the WebView documentation into a local ./docs folder. I've also started a new Guide.md file that I'd like to flesh out with dozens of code examples to show the most common use cases and best practices.

In the future, I'd like to see pull requests include updates to appropriate `./docs` files as well. @Titozzz we should enforce this as we review PRs.

Fixes #36.
