### PR TITLE
Fix WKWebView memory leak

### DIFF
--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -95,6 +95,8 @@ static NSString *const MessageHanderName = @"ReactNative";
     [self addSubview:_webView];
 
     [self visitSource];
+  } else {
+    [_webView.configuration.userContentController removeScriptMessageHandlerForName:MessageHanderName];
   }
 }
 


### PR DESCRIPTION
WKWebView was not able to dealloc upon removal of components. It was due to registration of script message handler with strong reference to self, resulting the webview context to remain in memory until the app shuts down.

You can check it by
1. using WKWebView component (<WebView useWebKit={true}/>)
2. Open safari debug menu > your app.
You can see the JS contexts of WKWebView remaining even after react component has been destroyed.

Test Plan:
----------
1. Implement WKWebView in a react app
2. Browse a page
3. Remove the component from view hierarchy
4. Check safari debug menu to see if the webview has been dealloc-ed correctly.

Release Notes:
--------------
[IOS] [BUGFIX] [./ios/RNCWKWebView.m#99] - Deregister script message handler when webview is removed from view hierarchy