### PR TITLE
Fix Android WebView when using UTF-8 characters (garbled output)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -506,7 +506,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           view.loadDataWithBaseURL(
               source.getString("baseUrl"), html, HTML_MIME_TYPE, HTML_ENCODING, null);
         } else {
-          view.loadData(html, HTML_MIME_TYPE, HTML_ENCODING);
+          view.loadData(html, HTML_MIME_TYPE + "; charset=" + HTML_ENCODING, null);
         }
         return;
       }


### PR DESCRIPTION
The fix code is taken from the last line of https://stackoverflow.com/a/10831462/728287

I'm testing Ukrainian Cyrilic characters

| Before        | After           |
| ------------- |:-------------:|
| <img src="https://user-images.githubusercontent.com/899175/46659207-25e7b600-cbbd-11e8-918f-0a1c6554e791.png" width="300" />   | <img src="https://user-images.githubusercontent.com/899175/46659209-2718e300-cbbd-11e8-84bc-f7c6e25b32ed.png" width="300" />

You can use this to test:
```jsx
<WebView
  // source={{ uri: 'https://hostmaster.ua/' }} // no currently an issue with websites
  source={{
  html: `<html>
    <head><meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0"></head>
    <body>
      <button id="btnSubmit">Створити картку</button>
    </body></html>`,
  }}
/>
```