### PR TITLE
Add license to podspec.

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    [
+      "@semantic-release/github",
+      {
+        "assets": ["package.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "contributors": [
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
+  "license": "MIT",
   "version": "0.0.0-development",
   "homepage": "https://github.com/react-native-community/react-native-webview#readme",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "0.0.0-development",
+  "version": "2.0.0",
   "homepage": "https://github.com/react-native-community/react-native-webview#readme",
   "scripts": {
     "test:ios:flow": "flow check",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "0.0.0-development",
   "homepage": "https://github.com/react-native-community/react-native-webview#readme",
   "scripts": {
     "test:ios:flow": "flow check",

--- a/react-native-webview.podspec
+++ b/react-native-webview.podspec
@@ -6,6 +6,7 @@ Pod::Spec.new do |s|
   s.name         = package['name']
   s.version      = package['version']
   s.summary      = package['description']
+  s.license      = package['license']
 
   s.authors      = package['author']
   s.homepage     = package['homepage']


### PR DESCRIPTION
Fix cocoapods install error and warning.
```
Fetching podspec for `react-native-webview` from `../node_modules/react-native-webview`
[!] The `react-native-webview` pod failed to validate due to 1 error:
    - WARN  | attributes: Missing required attribute `license`.
    - ERROR | version: The version of the spec should be higher than 0.
    - WARN  | license: Missing license type.
    - WARN  | source: Git sources should specify a tag.
```