### PR TITLE
Revamp of postMessage implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "prettier.singleQuote": true,
+    "prettier.trailingComma": "all"
+}

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -95,7 +95,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   protected static final String HTML_ENCODING = "UTF-8";
   protected static final String HTML_MIME_TYPE = "text/html";
   protected static final String WEBVIEW_MESSAGE_HANDLER = "window.webkit.messageHandlers.";
-  protected static final String BRIDGE_NAME = "ReactNativeBridge";
+  protected static final String HANDLER_NAME = "ReactNative";
 
   protected static final String HTTP_METHOD_POST = "POST";
 
@@ -266,7 +266,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
       /**
        * This method is called whenever JavaScript running within the web view calls:
-       *   - window.webkit.messageHandlers[BRIDGE_NAME].postMessage
+       *   - window.webkit.messageHandlers[HANDLER_NAME].postMessage
        */
       @JavascriptInterface
       public void postMessage(String message) {
@@ -326,9 +326,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       messagingEnabled = enabled;
 
       if (enabled) {
-        addJavascriptInterface(createRNCWebViewBridge(this), WEBVIEW_MESSAGE_HANDLER + BRIDGE_NAME);
+        addJavascriptInterface(createRNCWebViewBridge(this), WEBVIEW_MESSAGE_HANDLER + HANDLER_NAME);
       } else {
-        removeJavascriptInterface(WEBVIEW_MESSAGE_HANDLER + BRIDGE_NAME);
+        removeJavascriptInterface(WEBVIEW_MESSAGE_HANDLER + HANDLER_NAME);
       }
     }
 
@@ -378,7 +378,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         "window.originalPostMessage = window.postMessage;" +
         "window.postMessage = function(data, origin) {" +
           "window.originalPostMessage(data, origin);" +
-          WEBVIEW_MESSAGE_HANDLER + BRIDGE_NAME + ".postMessage(String(data));" +
+          WEBVIEW_MESSAGE_HANDLER + HANDLER_NAME + ".postMessage(String(data));" +
         "}" +
       ")");
     }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -359,12 +359,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           });
         }
 
-        evaluateJavascriptWithFallback("(" +
-          "window.originalPostMessage = window.postMessage," +
-          "window.postMessage = function(data) {" +
-            BRIDGE_NAME + ".postMessage(String(data));" +
-          "}" +
-        ")");
+        // evaluateJavascriptWithFallback("(" +
+        //   "window.originalPostMessage = window.postMessage," +
+        //   "window.postMessage = function(data) {" +
+        //     BRIDGE_NAME + ".postMessage(String(data));" +
+        //   "}" +
+        // ")");
       }
     }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -125,11 +125,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
       if (!mLastLoadFailed) {
         RNCWebView reactWebView = (RNCWebView) webView;
-        reactWebView.callInjectedJavaScript();
 
-        if (messagingEnabled && overwriteWindowPostMessage) {
-          reactWebView.overwritePostMessage();
-        }
+        reactWebView.callInjectedJavaScript();
 
         emitFinishEvent(webView, url);
       }
@@ -351,6 +348,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           injectedJS != null &&
           !TextUtils.isEmpty(injectedJS)) {
         evaluateJavascriptWithFallback("(function() {\n" + injectedJS + ";\n})();");
+      }
+      
+      if (messagingEnabled && overwriteWindowPostMessage) {
+        reactWebView.overwritePostMessage();
       }
     }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -351,7 +351,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       }
       
       if (messagingEnabled && overwriteWindowPostMessage) {
-        reactWebView.overwritePostMessage();
+        overwritePostMessage();
       }
     }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -327,20 +327,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       }
     }
 
-    public void setOverwriteWindowPostMessage(boolean overwrite) {
-      if (overwriteWindowPostMessage == overwrite) {
-        return;
-      }
-
-      overwriteWindowPostMessage = overwrite;
-
-      if (messagingEnabled && overwriteWindowPostMessage) {
-        overwritePostMessage();
-      } else {
-        restorePostMessage();
-      }
-    }
-
     protected void evaluateJavascriptWithFallback(String script) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
         evaluateJavascript(script, null);
@@ -367,6 +353,21 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       dispatchEvent(this, new TopMessageEvent(this.getId(), message));
     }
 
+    // Start of legacy code which overwrites window.postMessage
+    public void setOverwriteWindowPostMessage(boolean overwrite) {
+      if (overwriteWindowPostMessage == overwrite) {
+        return;
+      }
+
+      overwriteWindowPostMessage = overwrite;
+
+      if (messagingEnabled && overwriteWindowPostMessage) {
+        overwritePostMessage();
+      } else {
+        restorePostMessage();
+      }
+    }
+
     public void overwritePostMessage() {
       evaluateJavascriptWithFallback("(" +
         "window.originalPostMessage = window.postMessage;" +
@@ -382,6 +383,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         "window.postMessage = window.originalPostMessage || window.postMessage;" +
       ")");
     }
+    // End of legacy code which overwrites window.postMessage
 
     protected void cleanupCallbacksAndDestroy() {
       setWebViewClient(null);

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -126,6 +126,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       if (!mLastLoadFailed) {
         RNCWebView reactWebView = (RNCWebView) webView;
         reactWebView.callInjectedJavaScript();
+
+        if (messagingEnabled && overwriteWindowPostMessage) {
+          reactWebView.overwritePostMessage();
+        }
+
         emitFinishEvent(webView, url);
       }
     }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -94,7 +94,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   protected static final String HTML_ENCODING = "UTF-8";
   protected static final String HTML_MIME_TYPE = "text/html";
-  protected static final String BRIDGE_NAME = "__REACT_WEB_VIEW_BRIDGE";
+  protected static final String BRIDGE_NAME = "_ReactNativeBridge";
 
   protected static final String HTTP_METHOD_POST = "POST";
 
@@ -125,7 +125,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       if (!mLastLoadFailed) {
         RNCWebView reactWebView = (RNCWebView) webView;
         reactWebView.callInjectedJavaScript();
-        reactWebView.linkBridge();
         emitFinishEvent(webView, url);
       }
     }
@@ -314,9 +313,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       }
 
       messagingEnabled = enabled;
+
       if (enabled) {
         addJavascriptInterface(createRNCWebViewBridge(this), BRIDGE_NAME);
-        linkBridge();
       } else {
         removeJavascriptInterface(BRIDGE_NAME);
       }
@@ -341,30 +340,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           injectedJS != null &&
           !TextUtils.isEmpty(injectedJS)) {
         evaluateJavascriptWithFallback("(function() {\n" + injectedJS + ";\n})();");
-      }
-    }
-
-    public void linkBridge() {
-      if (messagingEnabled) {
-        if (ReactBuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-          // See isNative in lodash
-          String testPostMessageNative = "String(window.postMessage) === String(Object.hasOwnProperty).replace('hasOwnProperty', 'postMessage')";
-          evaluateJavascript(testPostMessageNative, new ValueCallback<String>() {
-            @Override
-            public void onReceiveValue(String value) {
-              if (value.equals("true")) {
-                FLog.w(ReactConstants.TAG, "Setting onMessage on a WebView overrides existing values of window.postMessage, but a previous value was defined");
-              }
-            }
-          });
-        }
-
-        // evaluateJavascriptWithFallback("(" +
-        //   "window.originalPostMessage = window.postMessage," +
-        //   "window.postMessage = function(data) {" +
-        //     BRIDGE_NAME + ".postMessage(String(data));" +
-        //   "}" +
-        // ")");
       }
     }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -94,7 +94,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   protected static final String HTML_ENCODING = "UTF-8";
   protected static final String HTML_MIME_TYPE = "text/html";
-  protected static final String BRIDGE_NAME = "_ReactNativeBridge";
+  protected static final String WEBVIEW_MESSAGE_HANDLER = "window.webkit.messageHandlers";
+  protected static final String BRIDGE_NAME = "ReactNativeBridge";
 
   protected static final String HTTP_METHOD_POST = "POST";
 
@@ -257,6 +258,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         mContext = c;
       }
 
+      /**
+       * This method is called whenever JavaScript running within the web view calls:
+       *   - window.webkit.messageHandlers[BRIDGE_NAME].postMessage
+       */
       @JavascriptInterface
       public void postMessage(String message) {
         mContext.onMessage(message);
@@ -315,9 +320,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       messagingEnabled = enabled;
 
       if (enabled) {
-        addJavascriptInterface(createRNCWebViewBridge(this), BRIDGE_NAME);
+        addJavascriptInterface(createRNCWebViewBridge(this), WEBVIEW_MESSAGE_HANDLER + BRIDGE_NAME);
       } else {
-        removeJavascriptInterface(BRIDGE_NAME);
+        removeJavascriptInterface(WEBVIEW_MESSAGE_HANDLER + BRIDGE_NAME);
       }
     }
 

--- a/ios/RNCUIWebView.m
+++ b/ios/RNCUIWebView.m
@@ -313,7 +313,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
           "window.location = '%@://%@?' + encodeURIComponent(messageQueue.shift());"
         "}"
 
-        "window.postMessage = function(data) {"
+        "window.postMessage = function(data, origin) {"
+          "window.originalPostMessage(data, origin);"
           "messageQueue.push(String(data));"
           "processQueue();"
         "};"

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -11,7 +11,7 @@
 
 #import "objc/runtime.h"
 
-static NSString *const MessageHandlerName = @"_ReactNativeBridge";
+static NSString *const MessageHandlerName = @"ReactNativeBridge";
 
 // runtime trick to remove WKWebView keyboard default toolbar
 // see: http://stackoverflow.com/questions/19033292/ios-7-uiwebview-keyboard-issue/19042279#19042279
@@ -144,7 +144,7 @@ static NSString *const MessageHandlerName = @"_ReactNativeBridge";
 
 /**
  * This method is called whenever JavaScript running within the web view calls:
- *   - window.[MessageHandlerName].postMessage
+ *   - window.webkit.messageHandlers[MessageHandlerName].postMessage
  */
 - (void)userContentController:(WKUserContentController *)userContentController
        didReceiveScriptMessage:(WKScriptMessage *)message

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -391,6 +391,7 @@ static NSString *const MessageHandlerName = @"ReactNativeBridge";
   }];
 }
 
+// Start of legacy code which overwrites window.postMessage
 - (void)overwritePostMessage
           thenCall: (void (^)(NSString*)) callback
 {
@@ -404,7 +405,7 @@ static NSString *const MessageHandlerName = @"ReactNativeBridge";
     "})();",
     MessageHandlerName
   ];
-  [self evaluateJS: source thenCall: nil];
+  [self evaluateJS: source thenCall: callback];
 }
 
 - (void)restorePostMessage
@@ -415,8 +416,9 @@ static NSString *const MessageHandlerName = @"ReactNativeBridge";
       "window.postMessage = window.originalPostMessage || window.postMessage;"
     "})();"
   ];
-  [self evaluateJS: source thenCall: nil];
+  [self evaluateJS: source thenCall: callback];
 }
+// End of legacy code which overwrites window.postMessage
 
 /**
  * Called when the navigation is complete.

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -408,6 +408,7 @@ static NSString *const MessageHandlerName = @"ReactNativeBridge";
   [self evaluateJS: source thenCall: callback];
 }
 
+// TODO: figure out how to call restorePostMessage when the overwriteWindowPostMessage prop changes
 - (void)restorePostMessage
           thenCall: (void (^)(NSString*)) callback
 {
@@ -429,9 +430,6 @@ static NSString *const MessageHandlerName = @"ReactNativeBridge";
 {
   if (_messagingEnabled && _overwriteWindowPostMessage) {
     [self overwritePostMessage thenCall: nil];
-  }
-  else {
-    [self restorePostMessage thenCall: nil];
   }
 
   if (_injectedJavaScript) {

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -11,7 +11,7 @@
 
 #import "objc/runtime.h"
 
-static NSString *const MessageHandlerName = @"ReactNativeBridge";
+static NSString *const MessageHandlerName = @"ReactNative";
 
 // runtime trick to remove WKWebView keyboard default toolbar
 // see: http://stackoverflow.com/questions/19033292/ios-7-uiwebview-keyboard-issue/19042279#19042279

--- a/ios/RNCWKWebViewManager.m
+++ b/ios/RNCWKWebViewManager.m
@@ -49,6 +49,7 @@ RCT_EXPORT_VIEW_PROPERTY(hideKeyboardAccessoryView, BOOL)
  * Expose methods to enable messaging the webview.
  */
 RCT_EXPORT_VIEW_PROPERTY(messagingEnabled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(overwriteWindowPostMessage, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onMessage, RCTDirectEventBlock)
 
 RCT_EXPORT_METHOD(postMessage:(nonnull NSNumber *)reactTag message:(NSString *)message)

--- a/js/WebView.android.js
+++ b/js/WebView.android.js
@@ -19,7 +19,7 @@ import {
   UIManager,
   View,
   Image,
-  requireNativeComponent
+  requireNativeComponent,
 } from 'react-native';
 
 import invariant from 'fbjs/lib/invariant';
@@ -72,7 +72,9 @@ class WebView extends React.Component<WebViewSharedProps, State> {
   };
 
   state = {
-    viewState: this.props.startInLoadingState ? WebViewState.LOADING : WebViewState.IDLE,
+    viewState: this.props.startInLoadingState
+      ? WebViewState.LOADING
+      : WebViewState.IDLE,
     lastErrorEvent: null,
   };
 
@@ -144,8 +146,9 @@ class WebView extends React.Component<WebViewSharedProps, State> {
         javaScriptEnabled={this.props.javaScriptEnabled}
         thirdPartyCookiesEnabled={this.props.thirdPartyCookiesEnabled}
         domStorageEnabled={this.props.domStorageEnabled}
-        messagingEnabled={typeof this.props.onMessage === 'function'}
         onMessage={this.onMessage}
+        messagingEnabled={typeof this.props.onMessage === 'function'}
+        overwriteWindowPostMessage={this.props.overwriteWindowPostMessage}
         overScrollMode={this.props.overScrollMode}
         contentInset={this.props.contentInset}
         automaticallyAdjustContentInsets={
@@ -284,11 +287,11 @@ class WebView extends React.Component<WebViewSharedProps, State> {
     const { onMessage } = this.props;
     onMessage && onMessage(event);
   };
-  
+
   onLoadingProgress = (event: WebViewProgressEvent) => {
-    const { onLoadProgress} = this.props;
+    const { onLoadProgress } = this.props;
     onLoadProgress && onLoadProgress(event);
-  }
+  };
 }
 
 const RNCWebView = requireNativeComponent('RNCWebView');

--- a/js/WebView.ios.js
+++ b/js/WebView.ios.js
@@ -237,8 +237,6 @@ class WebView extends React.Component<WebViewSharedProps, State> {
       source = { uri: this.props.url };
     }
 
-    const messagingEnabled = typeof this.props.onMessage === 'function';
-
     let NativeWebView = nativeConfig.component;
 
     if (this.props.useWebKit) {
@@ -266,8 +264,9 @@ class WebView extends React.Component<WebViewSharedProps, State> {
         onLoadingFinish={this._onLoadingFinish}
         onLoadingError={this._onLoadingError}
         onLoadingProgress={this._onLoadingProgress}
-        messagingEnabled={messagingEnabled}
         onMessage={this._onMessage}
+        messagingEnabled={typeof this.props.onMessage === 'function'}
+        overwriteWindowPostMessage={this.props.overwriteWindowPostMessage}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
         scalesPageToFit={scalesPageToFit}
         allowsInlineMediaPlayback={this.props.allowsInlineMediaPlayback}
@@ -424,9 +423,9 @@ class WebView extends React.Component<WebViewSharedProps, State> {
   };
 
   _onLoadingProgress = (event: WebViewProgressEvent) => {
-    const {onLoadProgress} = this.props;
+    const { onLoadProgress } = this.props;
     onLoadProgress && onLoadProgress(event);
-  }
+  };
 
   componentDidUpdate(prevProps: WebViewSharedProps) {
     if (!(prevProps.useWebKit && this.props.useWebKit)) {


### PR DESCRIPTION
This PR:
- Achieves consistent naming of the global ReactNative communication channel in the WebView between Android and iOS;
- Only calls the linkBridge functions in both Android and iOS when overwritePostMessage is set to true, as a result this package no longer clutters the window.postMessage by default;
- Renames MessageHanderName to MessageHandlerName.

Feedback is much appreciated!

Addresses:
https://github.com/react-native-community/react-native-webview/issues/23
https://github.com/react-native-community/react-native-webview/issues/66
https://github.com/react-native-community/react-native-webview/issues/79