### PR TITLE
Add `userScript`,`userScriptForMainFrameOnly` prop

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -45,6 +45,8 @@ This document lays out the current public properties and methods for the React N
 - [`html`](Reference.md#html)
 - [`hideKeyboardAccessoryView`](Reference.md#hidekeyboardaccessoryview)
 - [`allowsBackForwardNavigationGestures`](Reference.md#allowsbackforwardnavigationgestures)
+- [`userScript`](Reference.md#userScript)
+- [`userScriptForMainFrameOnly`](Reference.md#userScriptForMainFrameOnly)
 
 ## Methods Index
 
@@ -505,6 +507,21 @@ If true, this will be able horizontal swipe gestures when using the WKWebView. T
 | ------- | -------- | -------- |
 | boolean | No       | iOS      |
 
+### `userScript`
+
+The script will be injected into the webpage after the document finishes loading.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| string  | No       | iOS      |
+
+### `userScriptForMainFrameOnly`
+
+A Boolean value indicating whether the script should be injected only into the main frame(true) or into all frames(false). The default value is `false`.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
 
 ## Methods
 

--- a/ios/RNCWKWebView.h
+++ b/ios/RNCWKWebView.h
@@ -37,6 +37,8 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
 @property (nonatomic, assign) BOOL hideKeyboardAccessoryView;
 @property (nonatomic, assign) BOOL allowsBackForwardNavigationGestures;
+@property (nonatomic, copy) NSString *userScript;
+@property (nonatomic, assign) BOOL userScriptForMainFrameOnly;
 
 - (void)postMessage:(NSString *)message;
 - (void)injectJavaScript:(NSString *)script;

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -95,6 +95,13 @@ static NSString *const MessageHanderName = @"ReactNative";
    wkWebViewConfig.dataDetectorTypes = _dataDetectorTypes;
 #endif
 
+    if (_userScript) {
+      WKUserScript *userScript = [[WKUserScript alloc] initWithSource:_userScript
+                                                        injectionTime:WKUserScriptInjectionTimeAtDocumentEnd
+                                                     forMainFrameOnly:_userScriptForMainFrameOnly];
+      [wkWebViewConfig.userContentController addUserScript:userScript];
+    }
+
     _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
     _webView.scrollView.delegate = self;
     _webView.UIDelegate = self;
@@ -214,7 +221,7 @@ static NSString *const MessageHanderName = @"ReactNative";
 
 -(void)setHideKeyboardAccessoryView:(BOOL)hideKeyboardAccessoryView
 {
-    
+
     if (_webView == nil) {
         _savedHideKeyboardAccessoryView = hideKeyboardAccessoryView;
         return;
@@ -223,29 +230,29 @@ static NSString *const MessageHanderName = @"ReactNative";
     if (_savedHideKeyboardAccessoryView == false) {
         return;
     }
-    
+
     UIView* subview;
     for (UIView* view in _webView.scrollView.subviews) {
         if([[view.class description] hasPrefix:@"WK"])
             subview = view;
     }
-    
+
     if(subview == nil) return;
-    
+
     NSString* name = [NSString stringWithFormat:@"%@_SwizzleHelperWK", subview.class.superclass];
     Class newClass = NSClassFromString(name);
-    
+
     if(newClass == nil)
     {
         newClass = objc_allocateClassPair(subview.class, [name cStringUsingEncoding:NSASCIIStringEncoding], 0);
         if(!newClass) return;
-        
+
         Method method = class_getInstanceMethod([_SwizzleHelperWK class], @selector(inputAccessoryView));
         class_addMethod(newClass, @selector(inputAccessoryView), method_getImplementation(method), method_getTypeEncoding(method));
-        
+
         objc_registerClassPair(newClass);
     }
-    
+
     object_setClass(subview, newClass);
 }
 

--- a/ios/RNCWKWebViewManager.m
+++ b/ios/RNCWKWebViewManager.m
@@ -45,6 +45,8 @@ RCT_EXPORT_VIEW_PROPERTY(contentInset, UIEdgeInsets)
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustContentInsets, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideKeyboardAccessoryView, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsBackForwardNavigationGestures, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(userScript, NSString)
+RCT_EXPORT_VIEW_PROPERTY(userScriptForMainFrameOnly, BOOL)
 
 /**
  * Expose methods to enable messaging the webview.

--- a/js/WebView.ios.js
+++ b/js/WebView.ios.js
@@ -159,6 +159,14 @@ class WebView extends React.Component<WebViewSharedProps, State> {
         'The allowsBackForwardNavigationGestures property is not supported when useWebKit = false',
       );
     }
+    if (
+      !this.props.useWebKit &&
+      this.props.userScript !== undefined
+    ) {
+      console.warn(
+        'The userScript property is not supported when useWebKit = false',
+      );
+    }
   }
 
   render() {
@@ -284,6 +292,8 @@ class WebView extends React.Component<WebViewSharedProps, State> {
           this.props.mediaPlaybackRequiresUserAction
         }
         dataDetectorTypes={this.props.dataDetectorTypes}
+        userScript={this.props.userScript}
+        userScriptForMainFrameOnly={this.props.userScriptForMainFrameOnly}
         {...nativeConfig.props}
       />
     );

--- a/js/WebViewTypes.js
+++ b/js/WebViewTypes.js
@@ -229,6 +229,20 @@ export type IOSWebViewProps = $ReadOnly<{|
    * back-forward list navigations.
    */
   allowsBackForwardNavigationGestures?: ?boolean,
+
+  /**
+    * The script will be injected into the webpage after the document finishes loading.
+    * @platform ios
+    */
+  userScript?: ?string,
+
+  /**
+   * A Boolean value indicating whether the script should be injected
+   * only into the main frame(true) or into all frames(false).
+   * The default value is `false`.
+   * @platform ios
+   */
+  userScriptForMainFrameOnly?: ?boolean,
 |}>;
 
 export type AndroidWebViewProps = $ReadOnly<{|


### PR DESCRIPTION
As you know `WKWebView` has [WKUserScript feature](https://developer.apple.com/documentation/webkit/wkuserscript?language=objc). It provides the function to run JavaScript on every frame(iframe) of a web page. This feature can be useful in many cases.

Please review it positively.

Test Plan:
----------
I checked if the code below works. If `userScript` is injected into all frames, the color of the YouTube header title changes to red.

```js
render() {
  const userScript = 'var injectionNode = document.createElement("style"); injectionNode.innerHTML = ".html5-video-player a { color: red; }"; document.body.appendChild(injectionNode);';

  return (
    <View>
      <WebView
        source={{
          uri: 'https://www.youtube.com/embed/8qCociUB6aQ',
        }}
        userScript={userScript}
      />
    </View>
   );
}  
```

### Normal title

![default title](https://gist.githubusercontent.com/ifsnow/4ffc95a0670756e3bcd68e7b7965a61d/raw/86cd9c0a6b2cc5b89165e631a6622a23555c2f00/default.png)

### Title changed by `userScript`

![changed title](https://gist.github.com/ifsnow/4ffc95a0670756e3bcd68e7b7965a61d/raw/86cd9c0a6b2cc5b89165e631a6622a23555c2f00/after_userscript.png)
