### PR TITLE
Add 'userAgent' property to the iOS WKWebView.

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -342,11 +342,11 @@ Boolean value to enable third party cookies in the `WebView`. Used on Android Lo
 
 ### `userAgent`
 
-Sets the user-agent for the `WebView`.
+Sets the user-agent for the `WebView`. If you are using iOS WKWebView, it works as customUserAgent.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| string | No       | Android  |
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 ---
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -342,11 +342,11 @@ Boolean value to enable third party cookies in the `WebView`. Used on Android Lo
 
 ### `userAgent`
 
-Sets the user-agent for the `WebView`. If you are using iOS WKWebView, it works as customUserAgent.
+Sets the user-agent for the `WebView`. This will only work for iOS if you are using WKWebView, not UIWebView (see https://developer.apple.com/documentation/webkit/wkwebview/1414950-customuseragent).
 
-| Type   | Required |
-| ------ | -------- |
-| string | No       |
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | Android, iOS WKWebView  |
 
 ---
 

--- a/ios/RNCWKWebView.h
+++ b/ios/RNCWKWebView.h
@@ -37,6 +37,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
 @property (nonatomic, assign) BOOL hideKeyboardAccessoryView;
 @property (nonatomic, assign) BOOL allowsBackForwardNavigationGestures;
+@property (nonatomic, copy) NSString *userAgent;
 
 - (void)postMessage:(NSString *)message;
 - (void)injectJavaScript:(NSString *)script;

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -103,7 +103,9 @@ static NSString *const MessageHanderName = @"ReactNative";
     _webView.scrollView.bounces = _bounces;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
-
+    if (_userAgent) {
+      _webView.customUserAgent = _userAgent;
+    }
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
     if ([_webView.scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
       _webView.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;

--- a/ios/RNCWKWebViewManager.m
+++ b/ios/RNCWKWebViewManager.m
@@ -45,6 +45,7 @@ RCT_EXPORT_VIEW_PROPERTY(contentInset, UIEdgeInsets)
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustContentInsets, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideKeyboardAccessoryView, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsBackForwardNavigationGestures, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(userAgent, NSString)
 
 /**
  * Expose methods to enable messaging the webview.

--- a/js/WebView.ios.js
+++ b/js/WebView.ios.js
@@ -271,6 +271,7 @@ class WebView extends React.Component<WebViewSharedProps, State> {
         }
         hideKeyboardAccessoryView={this.props.hideKeyboardAccessoryView}
         allowsBackForwardNavigationGestures={this.props.allowsBackForwardNavigationGestures}
+        userAgent={this.props.userAgent}
         onLoadingStart={this._onLoadingStart}
         onLoadingFinish={this._onLoadingFinish}
         onLoadingError={this._onLoadingError}

--- a/js/WebViewTypes.js
+++ b/js/WebViewTypes.js
@@ -229,6 +229,10 @@ export type IOSWebViewProps = $ReadOnly<{|
    * back-forward list navigations.
    */
   allowsBackForwardNavigationGestures?: ?boolean,
+  /**
+   * The custom user agent string.
+   */
+  userAgent?: ?string,
 |}>;
 
 export type AndroidWebViewProps = $ReadOnly<{|


### PR DESCRIPTION
Add 'userAgent' property to the iOS WKWebView. 

The property to set the userAgent in the iOS WKWebview is [customUserAgent](https://developer.apple.com/documentation/webkit/wkwebview/1414950-customuseragent). But to make the interface the same, I set userAgent props to WKWebview customUserAgent.