### PR TITLE
Fix android webview onMessage should return baseEvent

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -369,7 +369,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
 
     public void onMessage(String message) {
-      dispatchEvent(this, new TopMessageEvent(this.getId(), message));
+      if (mRNCWebViewClient != null) {
+        WritableMap eventData = mRNCWebViewClient.createWebViewEvent(this, this.getUrl());
+        eventData.putString("data", message);
+        dispatchEvent(this, new TopMessageEvent(this.getId(), eventData));
+      }
     }
 
     protected void cleanupCallbacksAndDestroy() {

--- a/android/src/main/java/com/reactnativecommunity/webview/events/TopMessageEvent.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/events/TopMessageEvent.java
@@ -11,11 +11,11 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
 public class TopMessageEvent extends Event<TopMessageEvent> {
 
   public static final String EVENT_NAME = "topMessage";
-  private final String mData;
+  private WritableMap mEventData;
 
-  public TopMessageEvent(int viewId, String data) {
+  public TopMessageEvent(int viewId, WritableMap eventData) {
     super(viewId);
-    mData = data;
+    mEventData = eventData;
   }
 
   @Override
@@ -36,8 +36,6 @@ public class TopMessageEvent extends Event<TopMessageEvent> {
 
   @Override
   public void dispatch(RCTEventEmitter rctEventEmitter) {
-    WritableMap data = Arguments.createMap();
-    data.putString("data", mData);
-    rctEventEmitter.receiveEvent(getViewTag(), EVENT_NAME, data);
+    rctEventEmitter.receiveEvent(getViewTag(), EVENT_NAME, mEventData);
   }
 }


### PR DESCRIPTION
Fixes #119 

Following https://snack.expo.io/@jl9404/webview-demo, after this fix, android webview should be able to receive bridge event from webview with baseEvent (canGoBack, canGoFoward, etc...), this fix will sync the behaviour between Android and iOS