### PR TITLE
Updates Android implementation for urlPrefixesForDefaultIntent

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -30,6 +30,7 @@ import android.webkit.GeolocationPermissions;
 import android.webkit.JavascriptInterface;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -142,8 +143,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
               createWebViewEvent(webView, url)));
     }
 
-    @Override
-    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+    private boolean overrideUrlLoading(WebView view, String url) {
       if (url.equals(BLANK_URL)) return false;
 
       // url blacklisting
@@ -164,6 +164,24 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
       launchIntent(view.getContext(), url);
       return true;
+    }
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+      if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
+        return false;
+      } else {
+        return overrideUrlLoading(view, url);
+      }
+    }
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+        return overrideUrlLoading(view, request.getUrl().toString());
+      } else {
+        return false;
+      }
     }
 
     private void launchIntent(Context context, String url) {

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -44,6 +44,7 @@ This document lays out the current public properties and methods for the React N
 - [`html`](Reference.md#html)
 - [`hideKeyboardAccessoryView`](Reference.md#hidekeyboardaccessoryview)
 - [`allowsBackForwardNavigationGestures`](Reference.md#allowsbackforwardnavigationgestures)
+- [`urlPrefixesForDefaultIntent`](Reference.md#urlPrefixesForDefaultIntent)
 
 ## Methods Index
 
@@ -494,6 +495,14 @@ If true, this will be able horizontal swipe gestures when using the WKWebView. T
 | Type    | Required | Platform |
 | ------- | -------- | -------- |
 | boolean | No       | iOS      |
+
+### `urlPrefixesForDefaultIntent`
+
+Array of strings, any URL opened in the WebView with a matching prefix will open the URL on the default intent, i.e. prompt the user to open in their chosen browser. The default value is `null`.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | Android  |
 
 
 ## Methods


### PR DESCRIPTION
Updates Android implementation for urlPrefixesForDefaultIntent by providing [shouldOverrideUrlLoading](https://developer.android.com/reference/android/webkit/WebViewClient.html#shouldOverrideUrlLoading(android.webkit.WebView,%20android.webkit.WebResourceRequest)) method in place of deprecated method with the same name [shouldOverrideUrlLoading](https://developer.android.com/reference/android/webkit/WebViewClient.html#shouldOverrideUrlLoading(android.webkit.WebView,%20java.lang.String)).

I've left the deprecated method to support devices < API level 24. I've also updated the reference docs to add documentation for this prop.