### PR TITLE
Add fix for keyboard dismiss leaving viewport shifted in iOS 12

### DIFF
--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -11,6 +11,7 @@
 
 #import "objc/runtime.h"
 
+static NSTimer *keyboardTimer;
 static NSString *const MessageHanderName = @"ReactNative";
 
 // runtime trick to remove WKWebView keyboard default toolbar
@@ -74,6 +75,19 @@ static NSString *const MessageHanderName = @"ReactNative";
     _automaticallyAdjustContentInsets = YES;
     _contentInset = UIEdgeInsetsZero;
   }
+    
+  // Workaround for a keyboard dismissal bug present in iOS 12
+  // https://openradar.appspot.com/radar?id=5018321736957952
+  if (@available(iOS 12.0, *)) {
+    [[NSNotificationCenter defaultCenter]
+      addObserver:self
+      selector:@selector(keyboardWillHide)
+      name:UIKeyboardWillHideNotification object:nil];
+    [[NSNotificationCenter defaultCenter]
+      addObserver:self
+      selector:@selector(keyboardWillShow)
+      name:UIKeyboardWillShowNotification object:nil];
+  }
   return self;
 }
 
@@ -116,6 +130,25 @@ static NSString *const MessageHanderName = @"ReactNative";
   } else {
     [_webView.configuration.userContentController removeScriptMessageHandlerForName:MessageHanderName];
   }
+}
+
+-(void)keyboardWillHide
+{
+    keyboardTimer = [NSTimer scheduledTimerWithTimeInterval:0 target:self selector:@selector(keyboardDisplacementFix) userInfo:nil repeats:false];
+    [[NSRunLoop mainRunLoop] addTimer:keyboardTimer forMode:NSRunLoopCommonModes];
+}
+-(void)keyboardWillShow
+{
+    if (keyboardTimer != nil) {
+        [keyboardTimer invalidate];
+    }
+}
+-(void)keyboardDisplacementFix
+{
+    // https://stackoverflow.com/a/9637807/824966
+    [UIView animateWithDuration:.25 animations:^{
+        self.webView.scrollView.contentOffset = CGPointMake(0, 0);
+    }];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context{


### PR DESCRIPTION
There's currently a pretty major bug with WKWebView on iOS 12 that leaves the viewport awkwardly shifted upwards after the keyboard is dismissed. Makes using WebViews with forms an extremely janky experience.
https://openradar.appspot.com/radar?id=5018321736957952

The bug exists on any iOS 12 app compiled with Xcode 10 (which is almost all of them 😅)

This PR adds a keyboard listener that manually animates the content offset, shrinking it on keyboard dismiss. The solution is borrowed from this Ionic PR: https://github.com/ionic-team/cordova-plugin-ionic-webview/pull/201/files

The fix works seamlessly, however, I am unsure of what impact it may have elsewhere (if any).