### PR TITLE
Add "Frame load interrupted" error handling for OAuth for RNCWKWebView

### DIFF
--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -402,6 +402,13 @@ static NSString *const MessageHanderName = @"ReactNative";
       return;
     }
 
+    if ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102) {
+      // Error code 102 "Frame load interrupted" is raised by the WKWebView
+      // when the URL is from an http redirect. This is a common pattern when
+      // implementing OAuth with a WebView.
+      return;
+    }
+
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
     [event addEntriesFromDictionary:@{
       @"didFailProvisionalNavigation": @YES,


### PR DESCRIPTION
Adds the same code that is on `RNCUIWebview` https://github.com/react-native-community/react-native-webview/blob/master/ios/RNCUIWebView.m#L271 for the same purpose.

I came across this problem while implementing google SAML support with the RNCWKWebView.