### PR TITLE
Add incognito prop to iOS WKWebview

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -44,6 +44,7 @@ This document lays out the current public properties and methods for the React N
 - [`html`](Reference.md#html)
 - [`hideKeyboardAccessoryView`](Reference.md#hidekeyboardaccessoryview)
 - [`allowsBackForwardNavigationGestures`](Reference.md#allowsbackforwardnavigationgestures)
+- [`incognito`](Reference.md#incognito)
 - [`allowFileAccess`](Reference.md#allowFileAccess)
 - [`saveFormDataDisabled`](Reference.md#saveFormDataDisabled)
 
@@ -496,6 +497,16 @@ If true, this will be able horizontal swipe gestures when using the WKWebView. T
 | Type    | Required | Platform |
 | ------- | -------- | -------- |
 | boolean | No       | iOS      |
+
+---
+
+### `incognito`
+
+Does not store any data within the lifetime of the WebView.
+
+| Type    | Required | Platform      |
+| ------- | -------- | ------------- |
+| boolean | No       | iOS WKWebView |
 
 ---
 

--- a/ios/RNCWKWebView.h
+++ b/ios/RNCWKWebView.h
@@ -37,6 +37,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
 @property (nonatomic, assign) BOOL hideKeyboardAccessoryView;
 @property (nonatomic, assign) BOOL allowsBackForwardNavigationGestures;
+@property (nonatomic, assign) BOOL incognito;
 @property (nonatomic, copy) NSString *userAgent;
 
 - (void)postMessage:(NSString *)message;

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -99,6 +99,9 @@ static NSString *const MessageHanderName = @"ReactNative";
     };
 
     WKWebViewConfiguration *wkWebViewConfig = [WKWebViewConfiguration new];
+    if (_incognito) {
+      wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
+    }
     wkWebViewConfig.userContentController = [WKUserContentController new];
     [wkWebViewConfig.userContentController addScriptMessageHandler: self name: MessageHanderName];
     wkWebViewConfig.allowsInlineMediaPlayback = _allowsInlineMediaPlayback;

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -83,6 +83,7 @@ static NSString *const MessageHanderName = @"ReactNative";
     WKWebViewConfiguration *wkWebViewConfig = [WKWebViewConfiguration new];
     if (_incognito) {
       wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
+    }
     if(self.useSharedProcessPool) {
         wkWebViewConfig.processPool = [[RNCWKProcessPoolManager sharedManager] sharedProcessPool];
     }

--- a/ios/RNCWKWebViewManager.m
+++ b/ios/RNCWKWebViewManager.m
@@ -45,6 +45,7 @@ RCT_EXPORT_VIEW_PROPERTY(contentInset, UIEdgeInsets)
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustContentInsets, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideKeyboardAccessoryView, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsBackForwardNavigationGestures, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(incognito, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(userAgent, NSString)
 
 /**

--- a/js/WebView.ios.js
+++ b/js/WebView.ios.js
@@ -159,6 +159,15 @@ class WebView extends React.Component<WebViewSharedProps, State> {
         'The allowsBackForwardNavigationGestures property is not supported when useWebKit = false',
       );
     }
+
+    if (
+      !this.props.useWebKit &&
+      this.props.incognito
+    ) {
+      console.warn(
+        'The incognito property is not supported when useWebKit = false',
+      );
+    }
   }
 
   render() {
@@ -271,6 +280,7 @@ class WebView extends React.Component<WebViewSharedProps, State> {
         }
         hideKeyboardAccessoryView={this.props.hideKeyboardAccessoryView}
         allowsBackForwardNavigationGestures={this.props.allowsBackForwardNavigationGestures}
+        incognito={this.props.incognito}
         userAgent={this.props.userAgent}
         onLoadingStart={this._onLoadingStart}
         onLoadingFinish={this._onLoadingFinish}
@@ -444,6 +454,7 @@ class WebView extends React.Component<WebViewSharedProps, State> {
     }
 
     this._showRedboxOnPropChanges(prevProps, 'allowsInlineMediaPlayback');
+    this._showRedboxOnPropChanges(prevProps, 'incognito');
     this._showRedboxOnPropChanges(prevProps, 'mediaPlaybackRequiresUserAction');
     this._showRedboxOnPropChanges(prevProps, 'dataDetectorTypes');
 

--- a/js/WebViewTypes.js
+++ b/js/WebViewTypes.js
@@ -346,6 +346,11 @@ export type WebViewSharedProps =  $ReadOnly<{|
   source?: ?WebViewSource,
 
   /**
+   * Does not store any data within the lifetime of the WebView.
+   */
+  incognito?: ?boolean,
+
+  /**
    * Function that returns a view to show if there's an error.
    */
   renderError: (errorDomain: ?string, errorCode: number, errorDesc: string) => Element<any>, // view to show if there's an error


### PR DESCRIPTION
Allows the webview to be opened with an ephemeral data storage.

Looks like there is no out-of-the-box support for `UIWebView` so I didn't implement that.
I think there should be a relatively simple way to implement this on Android as well.