### PR TITLE
Don't allow the scrollView to scroll when `scrollEnabled={false}`.

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -421,7 +421,7 @@ With the [new WebKit](Reference.md#usewebkit) implementation, we have three new 
 
 ### `scrollEnabled`
 
-Boolean value that determines whether scrolling is enabled in the `WebView`. The default value is `true`.
+Boolean value that determines whether scrolling is enabled in the `WebView`. The default value is `true`. Setting this to `false` will prevent the webview from moving the document body when the keyboard appears over an input.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -24,7 +24,7 @@ static NSString *const MessageHanderName = @"ReactNative";
 }
 @end
 
-@interface RNCWKWebView () <WKUIDelegate, WKNavigationDelegate, WKScriptMessageHandler, UIScrollViewDelegate, RCTAutoInsetsProtocol>
+@interface RNCWKWebView () <WKUIDelegate, WKNavigationDelegate, WKScriptMessageHandler, UIScrollViewDelegate, RCTAutoInsetsProtocol, UIScrollViewDelegate>
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingStart;
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingFinish;
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingError;
@@ -302,6 +302,19 @@ static NSString *const MessageHanderName = @"ReactNative";
 {
   _scrollEnabled = scrollEnabled;
   _webView.scrollView.scrollEnabled = scrollEnabled;
+
+  // Override the scrollView delegate to prevent scrolling.
+  if (!scrollEnabled) {
+    _webView.scrollView.delegate = self;
+  } else {
+    _webView.scrollView.delegate = _webView;
+  }
+}
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+  // Don't allow scrolling the scrollView.
+  scrollView.bounds = _webView.bounds;
 }
 
 - (void)postMessage:(NSString *)message

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -24,7 +24,7 @@ static NSString *const MessageHanderName = @"ReactNative";
 }
 @end
 
-@interface RNCWKWebView () <WKUIDelegate, WKNavigationDelegate, WKScriptMessageHandler, UIScrollViewDelegate, RCTAutoInsetsProtocol, UIScrollViewDelegate>
+@interface RNCWKWebView () <WKUIDelegate, WKNavigationDelegate, WKScriptMessageHandler, UIScrollViewDelegate, RCTAutoInsetsProtocol>
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingStart;
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingFinish;
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingError;


### PR DESCRIPTION
I have a [demo](https://github.com/ccorcos/react-native-demo/tree/resize-bug-2) and a [demo fix](https://github.com/ccorcos/react-native-demo/tree/resize-bug-2-fix) showing how focusing an input towards the bottom of the screen causes the scroll view to shift the entire page. If `scrollEnabled={false}` then its impossible to scroll the body back into view. The image below shows what's going on.

![](https://github.com/ccorcos/react-native-demo/raw/resize-bug-2/bug.png)

This PR overrides the scroll view delegate to prevent this shift from occurring.