### PR TITLE
[android] replace deprecated `WebView.PictureListener`->`onContentSizeChange` impl

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -295,8 +295,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           this,
           new ContentSizeChangeEvent(
             this.getId(),
-            this.getWidth(),
-            this.getContentHeight()
+            w,
+            h
           )
         );
       }


### PR DESCRIPTION
### Description

The current implementation of `onContentSizeChange` uses an old deprecated API [setPictureListener](https://developer.android.com/reference/android/webkit/WebView.html#setPictureListener(android.webkit.WebView.PictureListener)) - it was deprecated in API 12 but this library is set to a minimum of API 16 - this API most likely doesn't exist on devices using newer APIs 💥 

I've swapped it out for [WebView#onSizeChanged](https://developer.android.com/reference/android/webkit/WebView#onSizeChanged(int,%20int,%20int,%20int))

### Release Notes

 - [ANDROID] [FIX] `onContentSizeChange` now uses `WebView`s own `onSizeChanged` events instead of the now deprecated API `setPictureListener`.