### PR TITLE
[ios] Add allowsLinkPreview property to WKWebView

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -47,6 +47,7 @@ This document lays out the current public properties and methods for the React N
 - [`allowFileAccess`](Reference.md#allowFileAccess)
 - [`saveFormDataDisabled`](Reference.md#saveFormDataDisabled)
 - [`pagingEnabled`](Reference.md#pagingEnabled)
+- [`allowsLinkPreview`](Reference.md#allowsLinkPreview)
 
 ## Methods Index
 
@@ -523,6 +524,14 @@ Sets whether the WebView should disable saving form data. The default value is `
 ### `pagingEnabled`
 
 If the value of this property is true, the scroll view stops on multiples of the scroll view’s bounds when the user scrolls. The default value is false.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
+
+### `allowsLinkPreview`
+
+A Boolean value that determines whether pressing on a link displays a preview of the destination for the link. In iOS this property is available on devices that support 3D Touch. In iOS 10 and later, the default value is true; before that, the default value is false.
 
 | Type    | Required | Platform |
 | ------- | -------- | -------- |

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -529,6 +529,8 @@ If the value of this property is true, the scroll view stops on multiples of the
 | ------- | -------- | -------- |
 | boolean | No       | iOS      |
 
+---
+
 ### `allowsLinkPreview`
 
 A Boolean value that determines whether pressing on a link displays a preview of the destination for the link. In iOS this property is available on devices that support 3D Touch. In iOS 10 and later, the default value is true; before that, the default value is false.

--- a/ios/RNCWKWebView.h
+++ b/ios/RNCWKWebView.h
@@ -39,6 +39,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL hideKeyboardAccessoryView;
 @property (nonatomic, assign) BOOL allowsBackForwardNavigationGestures;
 @property (nonatomic, copy) NSString *userAgent;
+@property (nonatomic, assign) BOOL allowsLinkPreview;
 
 - (void)postMessage:(NSString *)message;
 - (void)injectJavaScript:(NSString *)script;

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -113,7 +113,7 @@ static NSString *const MessageHanderName = @"ReactNative";
     _webView.scrollView.scrollEnabled = _scrollEnabled;
     _webView.scrollView.pagingEnabled = _pagingEnabled;
     _webView.scrollView.bounces = _bounces;
-    _webView.allowsLinkPreview = allowsLinkPreview;
+    _webView.allowsLinkPreview = _allowsLinkPreview;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
 

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -113,8 +113,10 @@ static NSString *const MessageHanderName = @"ReactNative";
     _webView.scrollView.scrollEnabled = _scrollEnabled;
     _webView.scrollView.pagingEnabled = _pagingEnabled;
     _webView.scrollView.bounces = _bounces;
+    _webView.allowsLinkPreview = allowsLinkPreview;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
+
     if (_userAgent) {
       _webView.customUserAgent = _userAgent;
     }

--- a/ios/RNCWKWebViewManager.m
+++ b/ios/RNCWKWebViewManager.m
@@ -47,6 +47,7 @@ RCT_EXPORT_VIEW_PROPERTY(hideKeyboardAccessoryView, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsBackForwardNavigationGestures, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(pagingEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(userAgent, NSString)
+RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 
 /**
  * Expose methods to enable messaging the webview.

--- a/js/WebView.ios.js
+++ b/js/WebView.ios.js
@@ -291,6 +291,7 @@ class WebView extends React.Component<WebViewSharedProps, State> {
           this.props.mediaPlaybackRequiresUserAction
         }
         dataDetectorTypes={this.props.dataDetectorTypes}
+        allowsLinkPreview={this.props.allowsLinkPreview}
         {...nativeConfig.props}
       />
     );

--- a/js/WebViewTypes.js
+++ b/js/WebViewTypes.js
@@ -241,6 +241,16 @@ export type IOSWebViewProps = $ReadOnly<{|
    * The custom user agent string.
    */
   userAgent?: ?string,
+
+  /**
+   * A Boolean value that determines whether pressing on a link
+   * displays a preview of the destination for the link.
+   *
+   * This property is available on devices that support 3D Touch.
+   * In iOS 10 and later, the default value is `true`; before that, the default value is `false`.
+   * @platform ios
+   */
+  allowsLinkPreview?: ?boolean,
 |}>;
 
 export type AndroidWebViewProps = $ReadOnly<{|

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -216,7 +216,17 @@ export interface IOSWebViewProps {
   /**
    * If true, this will be able horizontal swipe gestures when using the WKWebView. The default value is `false`.
    */
-  allowsBackForwardNavigationGestures?: boolean
+  allowsBackForwardNavigationGestures?: boolean;
+
+  /**
+   * A Boolean value that determines whether pressing on a link
+   * displays a preview of the destination for the link.
+   *
+   * This property is available on devices that support 3D Touch.
+   * In iOS 10 and later, the default value is `true`; before that, the default value is `false`.
+   * @platform ios
+   */
+  allowsLinkPreview?: boolean;
 }
 
 export interface AndroidWebViewProps {


### PR DESCRIPTION
### allowsLinkPreview
Boolean value that determines whether pressing on a link displays a preview of the destination for that link. This is specific to iOS with devices that support 3D Touch.

**More info:**
https://developer.apple.com/documentation/webkit/wkwebview/1415000-allowslinkpreview
