### PR TITLE
Surface evaluateJavaScript errors

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -102,7 +102,7 @@ Controls whether to adjust the content inset for web views that are placed behin
 
 ### `injectedJavaScript`
 
-Set this to provide JavaScript that will be injected into the web page when the view loads.
+Set this to provide JavaScript that will be injected into the web page when the view loads. Make sure the string evaluates to a valid type (`true` works) and doesn't otherwise throw an exception.
 
 | Type   | Required |
 | ------ | -------- |

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -429,8 +429,12 @@ static NSString *const MessageHanderName = @"ReactNative";
           thenCall: (void (^)(NSString*)) callback
 {
   [self.webView evaluateJavaScript: js completionHandler: ^(id result, NSError *error) {
-    if (error == nil && callback != nil) {
-      callback([NSString stringWithFormat:@"%@", result]);
+    if (error == nil) {
+      if (callback != nil) {
+        callback([NSString stringWithFormat:@"%@", result]);
+      }
+    } else {
+      RCTLogError(@"Error evaluating injectedJavaScript: This is possibly due to an unsupported return type. Try adding true to the end of your injectedJavaScript string.");
     }
   }];
 }


### PR DESCRIPTION
In the current code using `startInLoadingState` and `injectedJavaScript` will result in an infinite loading state if `injectedJavaScript` fails to evaluate for some reason. This adds a red box error when your `injectedJavaScript` fails to evaluate for some reason. In my case this was do to the JS string not returning a valid type so I've added a that as a potential solution in the error message and added some documentation to the API Reference with some additional warnings.

To reproduce the existing behavior setup a webview with `startInLoadingState` and `injectedJavaScript` that returns an invalid type (in my case it returned a function). You should see an infinite loading state as `onLoadEnd` is never called.

Try the same with this branch and you'll get a nice red box error suggesting one potential solution to the problem.

