### PR TITLE
Add file download support for Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -1,24 +1,32 @@
 
 package com.reactnativecommunity.webview;
 
+import android.Manifest;
 import android.app.Activity;
+import android.app.DownloadManager;
+import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
 import android.os.Parcelable;
 import android.provider.MediaStore;
 import android.support.annotation.RequiresApi;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.content.FileProvider;
 import android.util.Log;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
+import android.widget.Toast;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.modules.core.PermissionAwareActivity;
+import com.facebook.react.modules.core.PermissionListener;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,6 +45,9 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
   private ValueCallback<Uri> filePathCallbackLegacy;
   private ValueCallback<Uri[]> filePathCallback;
   private Uri outputFileUri;
+
+  private DownloadManager.Request downloadRequest;
+  private static final int FILE_DOWNLOAD_PERMISSION_REQUEST = 1;
 
   final String DEFAULT_MIME_TYPES = "*/*";
 
@@ -177,6 +188,37 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     return true;
   }
 
+  public void setDownloadRequest(DownloadManager.Request request) {
+    this.downloadRequest = request;
+  }
+
+  public void downloadFile() {
+    DownloadManager dm = (DownloadManager) getCurrentActivity().getBaseContext().getSystemService(Context.DOWNLOAD_SERVICE);
+    String downloadMessage = "Downloading";
+
+    dm.enqueue(this.downloadRequest);
+
+    Toast.makeText(getCurrentActivity().getApplicationContext(), downloadMessage, Toast.LENGTH_LONG).show();
+  }
+
+  public boolean grantFileDownloaderPermissions() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return true;
+    }
+
+    boolean result = true;
+    if (ContextCompat.checkSelfPermission(getCurrentActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+      result = false;
+    }
+
+    if (!result) {
+      PermissionAwareActivity activity = getPermissionAwareActivity();
+      activity.requestPermissions(new String[]{ Manifest.permission.WRITE_EXTERNAL_STORAGE }, FILE_DOWNLOAD_PERMISSION_REQUEST, webviewFileDownloaderPermissionListener);
+    }
+
+    return result;
+  }
+
   public RNCWebViewPackage getPackage() {
     return this.aPackage;
   }
@@ -306,4 +348,34 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     // will be an array with one empty string element, afaik
     return arr.length == 0 || (arr.length == 1 && arr[0].length() == 0);
   }
+
+  private PermissionAwareActivity getPermissionAwareActivity() {
+    Activity activity = getCurrentActivity();
+    if (activity == null) {
+        throw new IllegalStateException("Tried to use permissions API while not attached to an Activity.");
+    } else if (!(activity instanceof PermissionAwareActivity)) {
+        throw new IllegalStateException("Tried to use permissions API but the host Activity doesn't implement PermissionAwareActivity.");
+    }
+    return (PermissionAwareActivity) activity;
+  }
+
+  private PermissionListener webviewFileDownloaderPermissionListener = new PermissionListener() {
+    @Override
+    public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+      switch (requestCode) {
+        case FILE_DOWNLOAD_PERMISSION_REQUEST: {
+          // If request is cancelled, the result arrays are empty.
+          if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            if (downloadRequest != null) {
+              downloadFile();
+            }
+          } else {
+            Toast.makeText(getCurrentActivity().getApplicationContext(), "Cannot download files as permission was denied. Please provide permission to write to storage, in order to download files.", Toast.LENGTH_LONG).show();
+          }
+          return true;
+        }
+      }
+      return false;
+    }
+  };
 }

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -105,3 +105,28 @@ WebView.isFileUploadSupported().then(res => {
 
 ```
 
+### Add support for File Download
+
+##### iOS
+
+For iOS, all you need to do is specify the permissions in your `ios/[project]/Info.plist` file:
+
+Save to gallery:
+```
+<key>NSPhotoLibraryAddUsageDescription</key>
+<string>Save pictures for certain activities.</string>
+```
+
+##### Android
+
+Add permission in AndroidManifest.xml:
+```xml
+<manifest ...>
+  ......
+
+  <!-- this is required to save files on Android  -->
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+  ......
+</manifest>
+```

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -50,7 +50,7 @@ class MyWeb extends Component {
 }
 ```
 
-### Add support for File Upload
+### Add support for File Upload / Download
 
 ##### iOS
 
@@ -76,12 +76,12 @@ Video recording:
 
 ##### Android
 
-Add permission in AndroidManifest.xml:
+Add permission in AndroidManifest.xml **(required for file download)**:
 ```xml
 <manifest ...>
   ......
 
-  <!-- this is required only for Android 4.1-5.1 (api 16-22)  -->
+  <!-- this is required for file downlod on all Android versions and for file upload on Android 4.1-5.1 (api 16-22)  -->
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
   ......

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -50,7 +50,7 @@ class MyWeb extends Component {
 }
 ```
 
-### Add support for File Upload / Download
+### Add support for File Upload
 
 ##### iOS
 
@@ -76,12 +76,12 @@ Video recording:
 
 ##### Android
 
-Add permission in AndroidManifest.xml **(required for file download)**:
+Add permission in AndroidManifest.xml:
 ```xml
 <manifest ...>
   ......
 
-  <!-- this is required for file downlod on all Android versions and for file upload on Android 4.1-5.1 (api 16-22)  -->
+  <!-- this is required only for Android 4.1-5.1 (api 16-22)  -->
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
   ......


### PR DESCRIPTION
Addresses #80.

Caveat: I am not an Android developer. This code comes from a fork of the original RN WebView that we have been using in production for some time, so all credit goes to @Oblongmana: https://github.com/Oblongmana/react-native-webview-file-upload-android.

Setting up a DownloadManager for the WebView is pretty straightforward, as is adding any known cookies to the request. Most of the complication comes from the requirement after SDK 23 to ask the user for the WRITE_EXTERNAL_STORAGE permission. Unfortunately there is no mechanism to suspend the download request until permission is resolved so this code stores off the request and sets up a listener that enqueues the download once permissions are resolved so the user experience is really nice.

I didn't see anything in the way of tests or documentation that needs to be added for this change, so let me know if I missed anything. Thanks!