### PR TITLE
add style doc in reference.md

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -277,7 +277,7 @@ Boolean value that forces the `WebView` to show the loading view on the first lo
 
 ### `style`
 
-A style object that allow you to customize the `WebView` style. You have to add `flex: null` to the style if you want to use `height` property.
+A style object that allow you to customize the `WebView` style. Please not that there are default styles (example: you need to add `flex: 0` to the style if you want to use `height` property).
 
 | Type  | Required |
 | ----- | -------- |

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -275,6 +275,16 @@ Boolean value that forces the `WebView` to show the loading view on the first lo
 
 ---
 
+### `style`
+
+A style object that allow you to customize the `WebView` style. You have to add `flex: null` to the style if you want to use `height` property.
+
+| Type  | Required |
+| ----- | -------- |
+| style | No       |
+
+---
+
 ### `decelerationRate`
 
 A floating-point number that determines how quickly the scroll view decelerates after the user lifts their finger. You may also use the string shortcuts `"normal"` and `"fast"` which match the underlying iOS settings for `UIScrollViewDecelerationRateNormal` and `UIScrollViewDecelerationRateFast` respectively:


### PR DESCRIPTION
Add style doc, as discuss in #216, mention that if you need to add `flex: null` to make `height` work.
