### PR TITLE
[android] cleanup `build.gradle` & fix #218

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,92 +1,113 @@
 buildscript {
-    ext.kotlin_version = '1.2.71'
-    repositories {
-        google()
-        jcenter()
-        maven {
-            url 'https://maven.fabric.io/public'
-        }
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+  repositories {
+    google()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.2.1'
+  }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
 
 def DEFAULT_COMPILE_SDK_VERSION = 27
 def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
 def DEFAULT_TARGET_SDK_VERSION = 27
 
 android {
-    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
-    defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
-        versionCode 1
-        versionName "1.0"
+  compileSdkVersion rootProject.ext.has('compileSdkVersion') ? rootProject.ext.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+  buildToolsVersion rootProject.ext.has('buildToolsVersion') ? rootProject.ext.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+  defaultConfig {
+    minSdkVersion 16
+    targetSdkVersion rootProject.ext.has('targetSdkVersion') ? rootProject.ext.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+    versionCode 1
+    versionName "1.0"
+  }
+  buildTypes {
+    release {
+      minifyEnabled false
     }
-    buildTypes {
-        release {
-            minifyEnabled false
-        }
-    }
-    productFlavors {
-    }
-    lintOptions {
-        disable 'GradleCompatible'
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+  }
+  lintOptions {
+    disable 'GradleCompatible'
+  }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 repositories {
-    mavenCentral()
-    jcenter()
+  mavenCentral()
+  jcenter()
+
+  def found = false
+  def defaultDir = null
+  def androidSourcesName = 'React Native sources'
+
+  if (rootProject.ext.has('reactNativeAndroidRoot')) {
+    defaultDir = rootProject.ext.get('reactNativeAndroidRoot')
+  } else {
+    defaultDir = new File(
+      projectDir,
+      '/../../../node_modules/react-native/android'
+    )
+  }
+
+  if (defaultDir.exists()) {
     maven {
-        url 'https://maven.google.com/'
-        name 'Google'
+      url defaultDir.toString()
+      name androidSourcesName
     }
 
-    // Stolen from react-native-firebase, thanks dudes!
-    def found = false
+    logger.quiet(":${project.name}:reactNativeAndroidRoot ${defaultDir.canonicalPath}")
+    found = true
+  } else {
     def parentDir = rootProject.projectDir
-    def reactNativeAndroidName = 'React Native (Node Modules)'
 
-    1.upto(4, {
-        if (found) return true
-        parentDir = parentDir.parentFile
-        def reactNativeAndroid = new File(
-                parentDir,
-                'node_modules/react-native/android'
-        )
+    1.upto(5, {
+      if (found) return true
+      parentDir = parentDir.parentFile
 
-        if (reactNativeAndroid.exists()) {
-            maven {
-                url reactNativeAndroid.toString()
-                name reactNativeAndroidName
-            }
+      def androidSourcesDir = new File(
+        parentDir,
+        'node_modules/react-native'
+      )
 
-            println "${project.name}: using React Native sources from ${reactNativeAndroid.toString()}"
-            found = true
+      def androidPrebuiltBinaryDir = new File(
+        parentDir,
+        'node_modules/react-native/android'
+      )
+
+      if (androidPrebuiltBinaryDir.exists()) {
+        maven {
+          url androidPrebuiltBinaryDir.toString()
+          name androidSourcesName
         }
-    })
 
-    if (!found) {
-        throw new GradleException(
-                "${project.name}: unable to locate React Native Android sources, " +
-                        "ensure you have you installed React Native as a dependency and try again."
-        )
-    }
+        logger.quiet(":${project.name}:reactNativeAndroidRoot ${androidPrebuiltBinaryDir.canonicalPath}")
+        found = true
+      } else if (androidSourcesDir.exists()) {
+        maven {
+          url androidSourcesDir.toString()
+          name androidSourcesName
+        }
+
+        logger.quiet(":${project.name}:reactNativeAndroidRoot ${androidSourcesDir.canonicalPath}")
+        found = true
+      }
+    })
+  }
+
+  if (!found) {
+    throw new GradleException(
+      "${project.name}: unable to locate React Native android sources. " +
+        "Ensure you have you installed React Native as a dependency in your project and try again."
+    )
+  }
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  //noinspection GradleDynamicVersion
+  api 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
This changes the following:
 - Fixes #218 
 - Removed unused Kotlin config
 - Removed unused Fabric Maven config
 - Versions now correctly checking `rootProject.ext.X` instead of `rootProject.X` to match behaviour from all other libs (RNFB needs changing as well 🙈)
 - Swapped `implementation` for `api` for react native sources - only used to build.


![image](https://user-images.githubusercontent.com/5347038/50959941-1af23980-14bc-11e9-8677-e60f3ee744e7.png)
![image](https://user-images.githubusercontent.com/5347038/50959955-22b1de00-14bc-11e9-8afa-d1abbba46a64.png)

cc @terrytianliang