### PR TITLE
Add `androidHardwareAccelerationDisabled` prop

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -452,6 +452,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   @ReactProp(name = "javaScriptEnabled")
   public void setJavaScriptEnabled(WebView view, boolean enabled) {
     view.getSettings().setJavaScriptEnabled(enabled);
+    view.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+    FLog.w(ReactConstants.TAG, "Hello World from Margaret~~~~~~~~~~~~~~~~~~~~~");
   }
 
   @ReactProp(name = "overScrollMode")

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -452,8 +452,13 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   @ReactProp(name = "javaScriptEnabled")
   public void setJavaScriptEnabled(WebView view, boolean enabled) {
     view.getSettings().setJavaScriptEnabled(enabled);
-    view.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
-    FLog.w(ReactConstants.TAG, "Hello World from Margaret~~~~~~~~~~~~~~~~~~~~~");
+  }
+
+  @ReactProp(name = "androidHardwareAccelerationDisabled")
+  public void setHardwareAccelerationDisabled(WebView view, boolean disabled) {
+    if (disabled) {
+      view.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+    }
   }
 
   @ReactProp(name = "overScrollMode")

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -28,6 +28,7 @@ This document lays out the current public properties and methods for the React N
 - [`decelerationRate`](Reference.md#decelerationrate)
 - [`domStorageEnabled`](Reference.md#domstorageenabled)
 - [`javaScriptEnabled`](Reference.md#javascriptenabled)
+- [`androidHardwareAccelerationDisabled`](Reference.md#androidHardwareAccelerationDisabled)
 - [`mixedContentMode`](Reference.md#mixedcontentmode)
 - [`thirdPartyCookiesEnabled`](Reference.md#thirdpartycookiesenabled)
 - [`userAgent`](Reference.md#useragent)
@@ -301,6 +302,16 @@ Boolean value to control whether DOM Storage is enabled. Used only in Android.
 ### `javaScriptEnabled`
 
 Boolean value to enable JavaScript in the `WebView`. Used on Android only as JavaScript is enabled by default on iOS. The default value is `true`.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android  |
+
+---
+
+### `androidHardwareAccelerationDisabled`
+
+Boolean value to disable Hardware Acceleration in the `WebView`. Used on Android only as Hardware Acceleration is a feature only for Android. The default value is `false`.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |

--- a/js/WebView.android.js
+++ b/js/WebView.android.js
@@ -67,6 +67,7 @@ class WebView extends React.Component<WebViewSharedProps, State> {
     scalesPageToFit: true,
     allowFileAccess: false,
     saveFormDataDisabled: false,
+    androidHardwareAccelerationDisabled: false,
     originWhitelist: defaultOriginWhitelist,
   };
 
@@ -150,6 +151,7 @@ class WebView extends React.Component<WebViewSharedProps, State> {
         injectedJavaScript={this.props.injectedJavaScript}
         userAgent={this.props.userAgent}
         javaScriptEnabled={this.props.javaScriptEnabled}
+        androidHardwareAccelerationDisabled={this.props.androidHardwareAccelerationDisabled}
         thirdPartyCookiesEnabled={this.props.thirdPartyCookiesEnabled}
         domStorageEnabled={this.props.domStorageEnabled}
         messagingEnabled={typeof this.props.onMessage === 'function'}

--- a/js/WebViewTypes.js
+++ b/js/WebViewTypes.js
@@ -307,6 +307,13 @@ export type AndroidWebViewProps = $ReadOnly<{|
   javaScriptEnabled?: ?boolean,
 
   /**
+   * Boolean value to disable Hardware Acceleration in the `WebView`. Used on Android only
+   * as Hardware Acceleration is a feature only for Android. The default value is `false`.
+   * @platform android
+   */
+  androidHardwareAccelerationDisabled?: ?boolean,
+
+  /**
    * Boolean value to enable third party cookies in the `WebView`. Used on
    * Android Lollipop and above only as third party cookies are enabled by
    * default on Android Kitkat and below and on iOS. The default value is `true`.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -288,6 +288,13 @@ export interface AndroidWebViewProps {
   javaScriptEnabled?: boolean;
 
   /**
+   * Boolean value to disable Hardware Acceleration in the `WebView`. Used on Android only
+   * as Hardware Acceleration is a feature only for Android. The default value is `false`.
+   * @platform android
+   */
+  androidHardwareAccelerationDisabled?: ?boolean;
+
+  /**
    * Boolean value to enable third party cookies in the `WebView`. Used on
    * Android Lollipop and above only as third party cookies are enabled by
    * default on Android Kitkat and below and on iOS. The default value is `true`.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -292,7 +292,7 @@ export interface AndroidWebViewProps {
    * as Hardware Acceleration is a feature only for Android. The default value is `false`.
    * @platform android
    */
-  androidHardwareAccelerationDisabled?: ?boolean;
+  androidHardwareAccelerationDisabled?: boolean;
 
   /**
    * Boolean value to enable third party cookies in the `WebView`. Used on


### PR DESCRIPTION
Hardware acceleration is enabled by default if your Target API level is >=14. However, because hardware acceleration is not supported for all of the 2D drawing operations, turning it on might affect some of your custom views or drawing calls. To disable hardware acceleration in application level will slow down the app, so we'd better to add a prop to enable user to disable hardware acceleration for android platform in view level
 Please view the details in [Hardware acceleration](https://developer.android.com/guide/topics/graphics/hardware-accel#controlling)

