### PR TITLE
Allow _target links to be opened up in the same way as UIWebView.

### DIFF
--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -73,6 +73,17 @@ static NSString *const MessageHanderName = @"ReactNative";
   return self;
 }
 
+/**
+ * See https://stackoverflow.com/questions/25713069/why-is-wkwebview-not-opening-links-with-target-blank/25853806#25853806 for details.
+ */
+- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
+{
+  if (!navigationAction.targetFrame.isMainFrame) {
+    [webView loadRequest:navigationAction.request];
+  }
+  return nil;
+}
+
 - (void)didMoveToWindow
 {
   if (self.window != nil && _webView == nil) {


### PR DESCRIPTION
Fixes https://github.com/react-native-community/react-native-webview/issues/139 .