### PR TITLE
prevent overriding postMessage callback

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -137,8 +137,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
       if (!mLastLoadFailed) {
         RNCWebView reactWebView = (RNCWebView) webView;
-        reactWebView.callInjectedJavaScript();
         reactWebView.linkBridge();
+        reactWebView.callInjectedJavaScript();
         emitFinishEvent(webView, url);
       }
     }
@@ -356,8 +356,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         }
 
         evaluateJavascriptWithFallback("(" +
-          "window.originalPostMessage = window.postMessage," +
-          "window.postMessage = function(data) {" +
+          "window.nativePostMessage = function(data) {" +
             BRIDGE_NAME + ".postMessage(String(data));" +
           "}" +
         ")");

--- a/ios/RNCUIWebView.m
+++ b/ios/RNCUIWebView.m
@@ -302,8 +302,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     #endif
     NSString *source = [NSString stringWithFormat:
       @"(function() {"
-        "window.originalPostMessage = window.postMessage;"
-
         "var messageQueue = [];"
         "var messagePending = false;"
 
@@ -313,7 +311,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
           "window.location = '%@://%@?' + encodeURIComponent(messageQueue.shift());"
         "}"
 
-        "window.postMessage = function(data) {"
+        "window.nativePostMessage = function(data) {"
           "messageQueue.push(String(data));"
           "processQueue();"
         "};"

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -529,9 +529,7 @@ static NSString *const MessageHanderName = @"ReactNative";
 
     NSString *source = [NSString stringWithFormat:
       @"(function() {"
-        "window.originalPostMessage = window.postMessage;"
-
-        "window.postMessage = function(data) {"
+        "window.nativePostMessage = function(data) {"
           "window.webkit.messageHandlers.%@.postMessage(String(data));"
         "};"
       "})();",


### PR DESCRIPTION
Hello dear maintainers 👋 

We have an app which uses web views to display some dynamic web content (like voting for pictures etc.). Sadly CMS which injects JS into those pages relies on the `postMessage` callback. In the current implementation, this special CMS code gets deleted when postMessage is overridden.

We've changed react-native-webview to use `nativePostMessage` instead `postMessage`. It's been running on production for a few months already and we haven't spotted any problems with that change. 

Perhaps you will find it useful as well for other _consumers_ of your package.

Have an amazing day ᕕ( ᐛ )ᕗ