### PR TITLE
Deleted onShouldStartLoadWithRequest platform reference

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -260,9 +260,9 @@ On iOS, when [`useWebKit=true`](Reference.md#usewebkit), this prop will not work
 
 Function that allows custom handling of any web view requests. Return `true` from the function to continue loading the request and `false` to stop loading.
 
-| Type     | Required | Platform |
-| -------- | -------- | -------- |
-| function | No       | iOS      |
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
 
 ---
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -258,7 +258,9 @@ On iOS, when [`useWebKit=true`](Reference.md#usewebkit), this prop will not work
 
 ### `onShouldStartLoadWithRequest`
 
-Function that allows custom handling of any web view requests. Return `true` from the function to continue loading the request and `false` to stop loading.
+Function that allows custom handling of any web view requests. Return `true` from the function to continue loading the request and `false` to stop loading. 
+
+On Android, is not called on the first load.
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
according to https://github.com/react-native-community/react-native-webview/commit/b1b662628e3ceb5c89f1d105814f01c4aba0b701 it's supported on android and Ios so  no platform  reference is needed