### PR TITLE
Fix peerDependencies >=0.57 <0.59 (#279)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "react": "^16.0",
-    "react-native": "^0.57"
+    "react-native": ">=0.57 <0.59"
   },
   "dependencies": {
     "escape-string-regexp": "^1.0.5",


### PR DESCRIPTION
Fixes #279

The react-native version of peerDependencies remained at "^0.57".
