### PR TITLE
Add API Examples in reference documentation

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -145,6 +145,15 @@ Function that is invoked when the `WebView` load fails.
 | -------- | -------- |
 | function | No       |
 
+```javascript
+<WebView
+   source={{ uri: "https://infinite.red" }}
+   onError={(error) => {
+     console.error(error)
+   }}
+ />
+```
+
 ---
 
 ### `onLoad`
@@ -212,6 +221,15 @@ Function that is invoked when the `WebView` loading starts or ends.
 | -------- | -------- |
 | function | No       |
 
+```javascript
+<WebView
+   source={{ uri: "https://infinite.red" }}
+   onNavigationStateChange={(navState) => {
+    // Keep track of going back navigation within component
+    this.canGoBack = navState.canGoBack;
+}} />
+```
+
 ---
 
 ### `originWhitelist`
@@ -222,6 +240,13 @@ List of origin strings to allow being navigated to. The strings allow wildcards 
 | ---------------- | -------- |
 | array of strings | No       |
 
+```javascript
+//only allow URIs that begin with https:// or git://
+<WebView
+   source={{ uri: "https://infinite.red" }}
+   originWhitelist={['https://*', 'git://*']}
+ />
+```
 ---
 
 ### `renderError`
@@ -232,6 +257,13 @@ Function that returns a view to show if there's an error.
 | -------- | -------- |
 | function | No       |
 
+```javascript
+<WebView
+   source={{ uri: "https://infinite.red" }}
+   renderError={() => <Error /> }
+ />
+```
+
 ---
 
 ### `renderLoading`
@@ -241,6 +273,14 @@ Function that returns a loading indicator. The startInLoadingState prop must be 
 | Type     | Required |
 | -------- | -------- |
 | function | No       |
+
+```javascript
+<WebView
+   source={{ uri: "https://infinite.red" }}
+   startInLoadingState={true}
+   renderLoading={() => <Loading /> }
+ />
+```
 
 ---
 
@@ -264,6 +304,16 @@ Function that allows custom handling of any web view requests. Return `true` fro
 | -------- | -------- | -------- |
 | function | No       | iOS      |
 
+```javascript
+<WebView
+   source={{ uri: "https://infinite.red" }}
+   onShouldStartLoadWithRequest={(request) => {
+     // Only allow navigating within this website
+     return request.url.startsWith("https://infinite.red")
+   }}
+ />
+ ```
+ 
 ---
 
 ### `startInLoadingState`

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -182,6 +182,20 @@ Function that is invoked when the `WebView` has finished loading.
 | -------- | -------- |
 | function | No       |
 
+Example:
+
+```jsx
+<WebView
+  source={{uri: 'https://infinite.red'}}
+  onLoad={(syntheticEvent) => {
+    const { nativeEvent } = syntheticEvent;
+    this.url = nativeEvent.url;
+  }}
+/>
+```
+Function passed to onLoad is called with a SyntheticEvent
+
+
 ---
 
 ### `onLoadEnd`
@@ -192,6 +206,22 @@ Function that is invoked when the `WebView` load succeeds or fails.
 | -------- | -------- |
 | function | No       |
 
+
+Example:
+
+```jsx
+<WebView
+  source={{uri: 'https://infinite.red'}}
+  onLoadEnd={(syntheticEvent) => {
+    // update component to be aware of loading status
+    const { nativeEvent } = syntheticEvent;
+    this.isLoading = nativeEvent.loading;
+  }}
+/>
+```
+Function passed to onLoadEnd is called with a SyntheticEvent
+
+
 ---
 
 ### `onLoadStart`
@@ -201,6 +231,21 @@ Function that is invoked when the `WebView` starts loading.
 | Type     | Required |
 | -------- | -------- |
 | function | No       |
+
+
+Example:
+
+```jsx
+<WebView
+  source={{uri: 'https://infinite.red'}}
+  onLoadStart={(syntheticEvent) => {
+    // update component to be aware of loading status
+    const { nativeEvent } = syntheticEvent;
+    this.isLoading = nativeEvent.loading;
+  }}
+/>
+```
+Function passed to onLoadStart is called with a SyntheticEvent
 
 ---
 
@@ -216,6 +261,18 @@ Function that is invoked when the `WebView` is loading.
 | Type     | Required |
 | -------- | -------- |
 | function | No       |
+
+Example:
+
+```jsx
+<WebView
+   source={{ uri: "https://infinite.red" }}
+   onLoadProgress={({ nativeEvent }) => {
+     this.loadingProgress = nativeEvent.progress
+   }}
+ />
+```
+Function passed to onLoadProgress is called with a SyntheticEvent
 
 ---
 
@@ -389,6 +446,15 @@ A style object that allow you to customize the `WebView` style. Please note that
 | Type  | Required |
 | ----- | -------- |
 | style | No       |
+
+Example:
+
+```jsx
+<WebView
+   source={{ uri: "https://infinite.red" }}
+   style={{marginTop: 20}}
+ />
+```
 
 ---
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -149,7 +149,7 @@ Example:
 
 ```jsx
 <WebView
-   source={{ uri: "https://infinite.red" }}
+   source={{ uri: "https://facebook.github.io/react-native" }}
    onError={(syntheticEvent) => {
      const { nativeEvent } = syntheticEvent
      console.warn('WebView error: ', nativeEvent)
@@ -188,7 +188,7 @@ Example:
 
 ```jsx
 <WebView
-  source={{uri: 'https://infinite.red'}}
+  source={{uri: 'https://facebook.github.io/react-native'}}
   onLoad={(syntheticEvent) => {
     const { nativeEvent } = syntheticEvent;
     this.url = nativeEvent.url;
@@ -222,7 +222,7 @@ Example:
 
 ```jsx
 <WebView
-  source={{uri: 'https://infinite.red'}}
+  source={{uri: 'https://facebook.github.io/react-native'}}
   onLoadEnd={(syntheticEvent) => {
     // update component to be aware of loading status
     const { nativeEvent } = syntheticEvent;
@@ -257,7 +257,7 @@ Example:
 
 ```jsx
 <WebView
-  source={{uri: 'https://infinite.red'}}
+  source={{uri: 'https://facebook.github.io/react-native/='}}
   onLoadStart={(syntheticEvent) => {
     // update component to be aware of loading status
     const { nativeEvent } = syntheticEvent;
@@ -296,7 +296,7 @@ Example:
 
 ```jsx
 <WebView
-   source={{ uri: "https://infinite.red" }}
+   source={{ uri: "https://facebook.github.io/react-native" }}
    onLoadProgress={({ nativeEvent }) => {
      this.loadingProgress = nativeEvent.progress
    }}
@@ -341,7 +341,7 @@ Example:
 
 ```jsx
 <WebView
-   source={{ uri: "https://infinite.red" }}
+   source={{ uri: "https://facebook.github.io/react-native" }}
    onNavigationStateChange={(navState) => {
     // Keep track of going back navigation within component
     this.canGoBack = navState.canGoBack;
@@ -375,7 +375,7 @@ Example:
 ```jsx
 //only allow URIs that begin with https:// or git://
 <WebView
-   source={{ uri: "https://infinite.red" }}
+   source={{ uri: "https://facebook.github.io/react-native" }}
    originWhitelist={['https://*', 'git://*']}
  />
 ```
@@ -395,7 +395,7 @@ Example:
 
 ```jsx
 <WebView
-   source={{ uri: "https://infinite.red" }}
+   source={{ uri: "https://facebook.github.io/react-native" }}
    renderError={(errorName) => <Error name={errorName} /> }
  />
 ```
@@ -417,7 +417,7 @@ Example:
 
 ```jsx
 <WebView
-   source={{ uri: "https://infinite.red" }}
+   source={{ uri: "https://facebook.github.io/react-native" }}
    startInLoadingState={true}
    renderLoading={() => <Loading /> }
  />
@@ -449,10 +449,10 @@ Example:
 
 ```jsx
 <WebView
-  source={{ uri: "https://infinite.red" }}
+  source={{ uri: "https://facebook.github.io/react-native" }}
   onShouldStartLoadWithRequest={(request) => {
     // Only allow navigating within this website
-    return request.url.startsWith("https://infinite.red")
+    return request.url.startsWith("https://facebook.github.io/react-native")
   }}
 />
 ```
@@ -494,7 +494,7 @@ Example:
 
 ```jsx
 <WebView
-   source={{ uri: "https://infinite.red" }}
+   source={{ uri: "https://facebook.github.io/react-native" }}
    style={{marginTop: 20}}
  />
 ```

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -157,7 +157,7 @@ Example:
  />
 ```
 
-The `error` is a SyntheticEvent that wraps a nativeEvent with these properties:
+Function passed to `onError` is called with a SyntheticEvent wrapping a nativeEvent with these properties:
 
  ```
  canGoBack
@@ -171,6 +171,8 @@ The `error` is a SyntheticEvent that wraps a nativeEvent with these properties:
  title
  url
 ```
+> **_Note_**
+> Domain is only used on iOS
 
 ---
 
@@ -193,8 +195,17 @@ Example:
   }}
 />
 ```
-Function passed to onLoad is called with a SyntheticEvent
 
+Function passed to `onLoad` is called with a SyntheticEvent wrapping a nativeEvent with these properties:
+
+ ```
+ canGoBack
+ canGoForward
+ loading
+ target
+ title
+ url
+```
 
 ---
 
@@ -219,8 +230,17 @@ Example:
   }}
 />
 ```
-Function passed to onLoadEnd is called with a SyntheticEvent
 
+Function passed to `onLoadEnd` is called with a SyntheticEvent wrapping a nativeEvent with these properties:
+
+ ```
+ canGoBack
+ canGoForward
+ loading
+ target
+ title
+ url
+```
 
 ---
 
@@ -245,7 +265,17 @@ Example:
   }}
 />
 ```
-Function passed to onLoadStart is called with a SyntheticEvent
+
+Function passed to `onLoadStart` is called with a SyntheticEvent wrapping a nativeEvent with these properties:
+
+ ```
+ canGoBack
+ canGoForward
+ loading
+ target
+ title
+ url
+```
 
 ---
 
@@ -272,7 +302,18 @@ Example:
    }}
  />
 ```
-Function passed to onLoadProgress is called with a SyntheticEvent
+
+Function passed to `onLoadProgress` is called with a SyntheticEvent wrapping a nativeEvent with these properties:
+
+ ```
+ canGoBack
+ canGoForward
+ loading
+ progress
+ target
+ title
+ url
+```
 
 ---
 
@@ -318,6 +359,7 @@ The `navState` object includes these properties:
  title
  url
 ```
+
 ---
 
 ### `originWhitelist`
@@ -337,6 +379,7 @@ Example:
    originWhitelist={['https://*', 'git://*']}
  />
 ```
+
 ---
 
 ### `renderError`
@@ -357,7 +400,7 @@ Example:
  />
 ```
 
-The function passed to renderError will be called with the name of the error 
+The function passed to `renderError` will be called with the name of the error 
 
 ---
 
@@ -404,7 +447,7 @@ Function that allows custom handling of any web view requests. Return `true` fro
 
 Example:
 
- ```jsx
+```jsx
 <WebView
   source={{ uri: "https://infinite.red" }}
   onShouldStartLoadWithRequest={(request) => {
@@ -414,9 +457,9 @@ Example:
 />
 ```
 
- The `request` object includes these properties:
+The `request` object includes these properties:
 
- ```
+```
 title
 url
 loading
@@ -426,7 +469,7 @@ canGoForward
 lockIdentifier
 navigationType
 ```
- 
+
 ---
 
 ### `startInLoadingState`

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -145,13 +145,31 @@ Function that is invoked when the `WebView` load fails.
 | -------- | -------- |
 | function | No       |
 
-```javascript
+Example:
+
+```jsx
 <WebView
    source={{ uri: "https://infinite.red" }}
-   onError={(error) => {
-     console.error(error)
+   onError={(syntheticEvent) => {
+     const { nativeEvent } = syntheticEvent
+     console.warn('WebView error: ', nativeEvent)
    }}
  />
+```
+
+The `error` is a SyntheticEvent that wraps a nativeEvent with these properties:
+
+ ```
+ canGoBack
+ canGoForward
+ code
+ description
+ didFailProvisionalNavigation
+ domain
+ loading
+ target
+ title
+ url
 ```
 
 ---
@@ -221,7 +239,9 @@ Function that is invoked when the `WebView` loading starts or ends.
 | -------- | -------- |
 | function | No       |
 
-```javascript
+Example:
+
+```jsx
 <WebView
    source={{ uri: "https://infinite.red" }}
    onNavigationStateChange={(navState) => {
@@ -230,6 +250,17 @@ Function that is invoked when the `WebView` loading starts or ends.
 }} />
 ```
 
+The `navState` object includes these properties:
+
+ ```
+ canGoBack
+ canGoForward
+ loading
+ navigationType
+ target
+ title
+ url
+```
 ---
 
 ### `originWhitelist`
@@ -240,7 +271,9 @@ List of origin strings to allow being navigated to. The strings allow wildcards 
 | ---------------- | -------- |
 | array of strings | No       |
 
-```javascript
+Example:
+
+```jsx
 //only allow URIs that begin with https:// or git://
 <WebView
    source={{ uri: "https://infinite.red" }}
@@ -257,12 +290,17 @@ Function that returns a view to show if there's an error.
 | -------- | -------- |
 | function | No       |
 
-```javascript
+
+Example:
+
+```jsx
 <WebView
    source={{ uri: "https://infinite.red" }}
-   renderError={() => <Error /> }
+   renderError={(errorName) => <Error name={errorName} /> }
  />
 ```
+
+The function passed to renderError will be called with the name of the error 
 
 ---
 
@@ -274,7 +312,10 @@ Function that returns a loading indicator. The startInLoadingState prop must be 
 | -------- | -------- |
 | function | No       |
 
-```javascript
+
+Example:
+
+```jsx
 <WebView
    source={{ uri: "https://infinite.red" }}
    startInLoadingState={true}
@@ -304,15 +345,30 @@ Function that allows custom handling of any web view requests. Return `true` fro
 | -------- | -------- | -------- |
 | function | No       | iOS      |
 
-```javascript
+Example:
+
+ ```jsx
 <WebView
-   source={{ uri: "https://infinite.red" }}
-   onShouldStartLoadWithRequest={(request) => {
-     // Only allow navigating within this website
-     return request.url.startsWith("https://infinite.red")
-   }}
- />
+  source={{ uri: "https://infinite.red" }}
+  onShouldStartLoadWithRequest={(request) => {
+    // Only allow navigating within this website
+    return request.url.startsWith("https://infinite.red")
+  }}
+/>
+```
+
+ The `request` object includes these properties:
+
  ```
+title
+url
+loading
+target
+canGoBack
+canGoForward
+lockIdentifier
+navigationType
+```
  
 ---
 


### PR DESCRIPTION
Add example uses of

- onError
- onLoad
- onLoadEnd
- onLoadStart
- onLoadProgress
- onNavigationStateChange
- originWhitelist
- renderError
- renderLoading
- style