### PR TITLE
Add `cacheEnabled` prop to typescript prop type declarations

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -438,6 +438,12 @@ export interface WebViewSharedProps extends ViewProps, IOSWebViewProps, AndroidW
   originWhitelist?: string[];
 
   /**
+   * Boolean value that determines whether caching is enabled in the
+   * `WebView`. The default value is `true` - i.e. caching is *enabled by default*
+   */
+  cacheEnabled?: boolean,
+
+  /**
    * Override the native component used to render the WebView. Enables a custom native
    * WebView which uses the same JavaScript as the original WebView.
    */


### PR DESCRIPTION
This `cacheEnabled` prop was added in PR #152 but the typescript compiler was giving me an error when I tried to use it, so I've added it to the typescript declaration file.

I think this is a fairly simple and self-explanatory PR but let me know if you need any other details! 😃 