### PR TITLE
Fix crash with WebKit on iOS 9.x.

### DIFF
--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -43,8 +43,6 @@ static NSURLCredential* clientAuthenticationCredential;
   BOOL _savedHideKeyboardAccessoryView;
 }
 
-- (void)dealloc{}
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if ((self = [super initWithFrame:frame])) {
@@ -71,6 +69,11 @@ static NSURLCredential* clientAuthenticationCredential;
   }
 
   return self;
+}
+
+- (void)dealloc
+{
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 /**
@@ -164,6 +167,7 @@ static NSURLCredential* clientAuthenticationCredential;
         [_webView.configuration.userContentController removeScriptMessageHandlerForName:MessageHandlerName];
         [_webView removeObserver:self forKeyPath:@"estimatedProgress"];
         [_webView removeFromSuperview];
+        _webView.scrollView.delegate = nil;
         _webView = nil;
     }
 

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -45,24 +45,6 @@ static NSURLCredential* clientAuthenticationCredential;
 
 - (void)dealloc{}
 
-/**
- * See https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/DisplayWebContent/Tasks/WebKitAvail.html.
- */
-+ (BOOL)dynamicallyLoadWebKitIfAvailable
-{
-  static BOOL _webkitAvailable=NO;
-  static dispatch_once_t onceToken;
-
-  dispatch_once(&onceToken, ^{
-    NSBundle *webKitBundle = [NSBundle bundleWithPath:@"/System/Library/Frameworks/WebKit.framework"];
-    if (webKitBundle) {
-      _webkitAvailable = [webKitBundle load];
-    }
-  });
-
-  return _webkitAvailable;
-}
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if ((self = [super initWithFrame:frame])) {
@@ -105,10 +87,6 @@ static NSURLCredential* clientAuthenticationCredential;
 - (void)didMoveToWindow
 {
   if (self.window != nil && _webView == nil) {
-    if (![[self class] dynamicallyLoadWebKitIfAvailable]) {
-      return;
-    };
-
     WKWebViewConfiguration *wkWebViewConfig = [WKWebViewConfiguration new];
     if (_incognito) {
       wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];


### PR DESCRIPTION
This PR fixes two crashes when enableWebKit is true (which was the default) on iOS 9.x. The first one when the WebView component was mounted (fixes issue #150) and the second one, when the component was unmounted (fixes issue #213).

The first problem happen when the RNCWKWebView.m was loaded:

The programming guide for WebKit (version 2006) ([pdf](http://mirror.informatimago.com/next/developer.apple.com/documentation/Cocoa/Conceptual/DisplayWebContent/WebKit_DisplayWebContent.pdf)) from Apple said, that it is (was) required to check if the 'new' WebKit Framework was available. This was required when the WebKit framework was only available on Mac OS X (10.2) when the Safari was installed. 😆

Because WebKit is (currently..) a fix part of iOS we didn't need this check this anymore to determinate if WebKit is available. I also see no other reference that this is required in iOS so I just remove this code. Without this code the WebView works also on iOS 9.x.

The second issue happen when the WKWebView was removed from the native view hierarchy. Its required (only on iOS 9) to remove the UIScrollView delegate before cleaning up the webview.

Its possible to try this PR with:

```
npm install --save "react-native-webview@jerolimov/react-native-webview#fix-ios9-crash"
# or
yarn add "react-native-webview@jerolimov/react-native-webview#fix-ios9-crash"
```

If you use CocoaPods, you should also update your Pods with

```
cd ios && pod update && cd ..
```