### PR TITLE
Remove Xcode warnings in native files

### DIFF
--- a/ios/RNCUIWebView.m
+++ b/ios/RNCUIWebView.m
@@ -44,7 +44,9 @@ static NSString *const MessageHandlerName = @"ReactNativeWebView";
     _webView.delegate = self;
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
     if ([_webView.scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
-      _webView.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+      if (@available(iOS 11.0, *)) {
+        _webView.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+      }
     }
 #endif
     [self addSubview:_webView];

--- a/ios/RNCUIWebViewManager.m
+++ b/ios/RNCUIWebViewManager.m
@@ -59,7 +59,7 @@ RCT_EXPORT_METHOD(goBack:(nonnull NSNumber *)reactTag)
 RCT_EXPORT_METHOD(goForward:(nonnull NSNumber *)reactTag)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-    RNCUIWebView *view = viewRegistry[reactTag];
+    RNCUIWebView *view = (RNCUIWebView *) viewRegistry[reactTag];
     if (![view isKindOfClass:[RNCUIWebView class]]) {
       RCTLogError(@"Invalid view returned from registry, expecting RNCUIWebView, got: %@", view);
     } else {

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -138,16 +138,18 @@ static NSURLCredential* clientAuthenticationCredential;
     _webView.allowsLinkPreview = _allowsLinkPreview;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
-
+    
     if (_userAgent) {
       _webView.customUserAgent = _userAgent;
     }
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
     if ([_webView.scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
-      _webView.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+      if (@available(iOS 11.0, *)) {
+        _webView.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+      }
     }
 #endif
-
+    
     [self addSubview:_webView];
     [self setHideKeyboardAccessoryView: _savedHideKeyboardAccessoryView];
     [self visitSource];
@@ -522,7 +524,7 @@ static NSURLCredential* clientAuthenticationCredential;
     if (![self.delegate webView:self
       shouldStartLoadForRequest:event
                    withCallback:_onShouldStartLoadWithRequest]) {
-      decisionHandler(WKNavigationResponsePolicyCancel);
+      decisionHandler(WKNavigationActionPolicyCancel);
       return;
     }
   }
@@ -541,7 +543,7 @@ static NSURLCredential* clientAuthenticationCredential;
   }
 
   // Allow all navigation by default
-  decisionHandler(WKNavigationResponsePolicyAllow);
+  decisionHandler(WKNavigationActionPolicyAllow);
 }
 
 /**

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -454,8 +454,8 @@ static NSURLCredential* clientAuthenticationCredential;
  * topViewController
  */
 -(UIViewController *)topViewController{
-   UIViewController *controller = [self topViewControllerWithRootViewController:[self getCurrentWindow].rootViewController];
-   return controller;
+  UIViewController *controller = [self topViewControllerWithRootViewController:[self getCurrentWindow].rootViewController];
+  return controller;
 }
 
 /**

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -138,7 +138,7 @@ static NSURLCredential* clientAuthenticationCredential;
     _webView.allowsLinkPreview = _allowsLinkPreview;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
-    
+
     if (_userAgent) {
       _webView.customUserAgent = _userAgent;
     }
@@ -149,7 +149,7 @@ static NSURLCredential* clientAuthenticationCredential;
       }
     }
 #endif
-    
+
     [self addSubview:_webView];
     [self setHideKeyboardAccessoryView: _savedHideKeyboardAccessoryView];
     [self visitSource];


### PR DESCRIPTION
**Description:**
In our project we treat warning as an error. While we manually link react-native-webview, we found that there were following warnings were needed to be fixed for us to compile our project.

**Changes:**
- Removed unicode chars which were treated as space char.
- Cast object type instead of implicit conversion from UIView to RNCUIWebView
- Add @available to check if the api is available (To silent the Xcode warning)
- The decision handler expects enum type WKNavigationAction. But we were returning WKNavigationResponse which threw warning for converting enum type implicitly.

**Tests:** 
There are no changes that would require a unit tests.
