### PR TITLE
Add getting started doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Note: React Native WebView is not currently supported by Expo unless you "eject
 
 ## Getting Started
 
-Read our [Getting Started Guide]. If any step seems unclear, please create a detailed issue.
+Read our [Getting Started Guide](docs/Getting-Started.md). If any step seems unclear, please create a detailed issue.
 
 ## Versioning
 


### PR DESCRIPTION
The link was missing in the README for the getting started page, the square brackets were there though so looks like whoever wrote it just forgot to put the link there.