### PR TITLE
Add typescript definition for isFileUploadSupported

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -454,6 +454,7 @@ export interface WebViewSharedProps extends ViewProps, IOSWebViewProps, AndroidW
 }
 
 export class WebView extends Component<WebViewSharedProps> {
+  static isFileUploadSupported: () => Promise<boolean>;
   public goForward: () => void;
   public goBack: () => void;
   public reload: () => void;


### PR DESCRIPTION
This static async function was missing a type definition for typescript so I added one 😄 

Before:
<img width="355" alt="screen shot 2019-03-06 at 10 56 40 am" src="https://user-images.githubusercontent.com/1944151/53905942-95dc5a00-3ffe-11e9-8032-e2d3aa357f4d.png">

After:
<img width="609" alt="screen shot 2019-03-06 at 10 56 15 am" src="https://user-images.githubusercontent.com/1944151/53905961-9e349500-3ffe-11e9-9c54-d9c8e86061a9.png">
