### PR TITLE
OnOriginWhitelistFailed overrides default behaviour Open Link in Safari

### DIFF
--- a/js/WebView.android.js
+++ b/js/WebView.android.js
@@ -139,6 +139,7 @@ class WebView extends React.Component<WebViewSharedProps, State> {
       this.onShouldStartLoadWithRequestCallback,
       this.props.originWhitelist,
       this.props.onShouldStartLoadWithRequest,
+      this.props.onOriginWhitelistFailed
     );
 
     const webView = (

--- a/js/WebView.ios.js
+++ b/js/WebView.ios.js
@@ -226,6 +226,7 @@ class WebView extends React.Component<WebViewSharedProps, State> {
       this.onShouldStartLoadWithRequestCallback,
       this.props.originWhitelist,
       this.props.onShouldStartLoadWithRequest,
+      this.props.onOriginWhitelistFailed
     );
 
     const decelerationRate = processDecelerationRate(

--- a/js/WebViewShared.js
+++ b/js/WebViewShared.js
@@ -13,7 +13,7 @@ import { Linking } from 'react-native';
 import type {
   WebViewNavigationEvent,
   WebViewNavigation,
-  OnShouldStartLoadWithRequest,
+  OnShouldStartLoadWithRequest, OnOriginWhitelistFailed,
 } from './WebViewTypes';
 
 const defaultOriginWhitelist = ['http://*', 'https://*'];
@@ -44,13 +44,20 @@ const createOnShouldStartLoadWithRequest = (
   ) => void,
   originWhitelist: ?$ReadOnlyArray<string>,
   onShouldStartLoadWithRequest: ?OnShouldStartLoadWithRequest,
+  onOriginWhitelistFailed: ?OnOriginWhitelistFailed,
 ) => {
   return ({ nativeEvent }: WebViewNavigationEvent) => {
     let shouldStart = true;
     const { url, lockIdentifier } = nativeEvent;
 
     if (!passesWhitelist(compileWhitelist(originWhitelist), url)) {
-      Linking.openURL(url);
+      if(onOriginWhitelistFailed != null)
+      {
+        onOriginWhitelistFailed(nativeEvent)
+      }
+      else {
+        Linking.openURL(url);
+      }
       shouldStart = false
     }
 

--- a/js/WebViewTypes.js
+++ b/js/WebViewTypes.js
@@ -136,8 +136,12 @@ export type WebViewNativeConfig = $ReadOnly<{|
 |}>;
 
 export type OnShouldStartLoadWithRequest = (
-  event: WebViewNavigation,
+    event: WebViewNavigation,
 ) => boolean;
+
+export type OnOriginWhitelistFailed = (
+    event: WebViewNavigation,
+) => void;
 
 export type IOSWebViewProps = $ReadOnly<{|
   /**
@@ -487,10 +491,17 @@ export type WebViewSharedProps = $ReadOnly<{|
    * List of origin strings to allow being navigated to. The strings allow
    * wildcards and get matched against *just* the origin (not the full URL).
    * If the user taps to navigate to a new page but the new page is not in
-   * this whitelist, we will open the URL in Safari.
+   * this whitelist, we will open the URL in Safari or can be overwritten
+   * with onOriginWhiteListFailed.
    * The default whitelisted origins are "http://*" and "https://*".
    */
   originWhitelist?: $ReadOnlyArray<string>,
+
+  /**
+   * Overrides default behaviour of opening urls, which are not
+   * whitelisted in originWhitelist
+   */
+  onOriginWhitelistFailed?: OnOriginWhitelistFailed,
 
   /**
    * Function that allows custom handling of any web view requests. Return

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -439,10 +439,17 @@ export interface WebViewSharedProps extends ViewProps, IOSWebViewProps, AndroidW
    * List of origin strings to allow being navigated to. The strings allow
    * wildcards and get matched against *just* the origin (not the full URL).
    * If the user taps to navigate to a new page but the new page is not in
-   * this whitelist, we will open the URL in Safari.
+   * this whitelist, we will open the URL in Safari or can be overwritten
+   * with onOriginWhiteListFailed.
    * The default whitelisted origins are "http://*" and "https://*".
    */
   originWhitelist?: string[];
+
+  /**
+   * Overrides default behaviour of opening urls, which are not
+   * whitelisted in originWhitelist
+   */
+  onOriginWhitelistFailed?: (event: WebViewIOSLoadRequestEvent) => any;
 
   /**
    * Boolean value that determines whether caching is enabled in the


### PR DESCRIPTION
default behaviour of opening not whitelisted links in safari can be overwritten with this prop. 

Usefull if you want to keep the user in the app and present an for example an "In App Browser" or asking him if he really wants to open url in browser, instead of sending him to standard browser