### PR TITLE
fix(android): Annotate RNCWebViewModule with @ReactModule to comply with latest changes

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -25,6 +25,7 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
 
@@ -34,8 +35,9 @@ import java.util.ArrayList;
 
 import static android.app.Activity.RESULT_OK;
 
+@ReactModule(name = RNCWebViewModule.MODULE_NAME)
 public class RNCWebViewModule extends ReactContextBaseJavaModule implements ActivityEventListener {
-
+  public static final String MODULE_NAME = "RNCWebView";
   private static final int PICKER = 1;
   private static final int PICKER_LEGACY = 3;
   private static final int FILE_DOWNLOAD_PERMISSION_REQUEST = 1;
@@ -71,7 +73,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
 
   @Override
   public String getName() {
-    return "RNCWebView";
+    return MODULE_NAME;
   }
 
   @ReactMethod


### PR DESCRIPTION
The app was crashing with `"Could not find @ReactModule annotation in class RNCWebViewModule"` exception. Searching for this message in RN's code I found [this commit](https://github.com/facebook/react-native/commit/0cd3994f1a4ec1172af840cf5de3dddb1ae9e9c4), introduced in React Native 0.58, which requires native modules to be annotated with @ReactModule annotation. 🤔 

After adding the annotation to the module, tapping on a file input field no longer crashes the app (in fact it shows the file browser). 🎉 

I haven't had caught it previously, testing only against React Native 0.57, sorry! 😞 

For reference see similar fix in `react-native-gesture-handler` — https://github.com/kmagiera/react-native-gesture-handler/pull/295.

Fixes https://github.com/react-native-community/react-native-webview/issues/458.