### PR TITLE
Removes hard-coded container white backgroundColor

### DIFF
--- a/src/WebView.styles.ts
+++ b/src/WebView.styles.ts
@@ -15,7 +15,6 @@ const styles = StyleSheet.create<Styles>({
   container: {
     flex: 1,
     overflow: 'hidden',
-    backgroundColor: 'white',
   },
   errorContainer: {
     flex: 1,


### PR DESCRIPTION
Fixes #475

#472 added a `backgroundColor` of `white` to the `container` style which broke the ability to set a `transparent` background color on the `WebView` component. This simply removes that unnecessary style.