### PR TITLE
Remove duplicate example of onShouldStartLoadWithRequest

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -477,31 +477,6 @@ lockIdentifier
 navigationType
 ```
 
-Example:
-
-```jsx
-<WebView
-  source={{ uri: 'https://facebook.github.io/react-native' }}
-  onShouldStartLoadWithRequest={request => {
-    // Only allow navigating within this website
-    return request.url.startsWith('https://facebook.github.io/react-native');
-  }}
-/>
-```
-
-The `request` object includes these properties:
-
-```
-title
-url
-loading
-target
-canGoBack
-canGoForward
-lockIdentifier
-navigationType
-```
-
 ---
 
 ### `startInLoadingState`


### PR DESCRIPTION
There is a duplicate example for onShouldStartLoadWithRequest. This removes the duplicate example.