### PR TITLE
fix(android): updating source.html prop doesn't refresh webview

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -373,12 +373,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     if (source != null) {
       if (source.hasKey("html")) {
         String html = source.getString("html");
-        if (source.hasKey("baseUrl")) {
-          view.loadDataWithBaseURL(
-            source.getString("baseUrl"), html, HTML_MIME_TYPE, HTML_ENCODING, null);
-        } else {
-          view.loadData(html, HTML_MIME_TYPE + "; charset=" + HTML_ENCODING, null);
-        }
+        String baseUrl = source.hasKey("baseUrl") ? source.getString("baseUrl") : "";
+        view.loadDataWithBaseURL(baseUrl, html, HTML_MIME_TYPE, HTML_ENCODING, null);
         return;
       }
       if (source.hasKey("uri")) {


### PR DESCRIPTION
While doing some testing of using the `source.html` prop and setting it to raw HTML, I noticed that changing the raw HTML didn't cause an update of the displayed WebView content on Android. iOS works fine.

Doing some research finds a lot of people online encountering bugs with the `WebView.loadData` function. For example:
 - https://stackoverflow.com/questions/4096783/android-webview-1st-loaddata-works-fine-subsequent-calls-do-not-update-disp
 - https://stackoverflow.com/questions/17501860/had-to-load-data-twice-to-make-webview-refresh-in-android

The recommendation that this PR follows is to never use `loadData` and instead always use `loadDataWithBaseURL` and just don't pass in a `baseUrl` if we don't have one.