### PR TITLE
fix: iOS crash when WebView's title is nil

### DIFF
--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -460,7 +460,7 @@ static NSURLCredential* clientAuthenticationCredential;
 {
   NSDictionary *event = @{
     @"url": _webView.URL.absoluteString ?: @"",
-    @"title": _webView.title,
+    @"title": _webView.title ?: @"",
     @"loading" : @(_webView.loading),
     @"canGoBack": @(_webView.canGoBack),
     @"canGoForward" : @(_webView.canGoForward)


### PR DESCRIPTION
This crash is found in our fabric.

I can't reproduce it.

But this protection is needed because in Apple's doc the title property is nullable.