### PR TITLE
Add incognito prop to Android RNCWebViewManager

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -328,6 +328,23 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   public void setMessagingEnabled(WebView view, boolean enabled) {
     ((RNCWebView) view).setMessagingEnabled(enabled);
   }
+   
+  @ReactProp(name = "incognito")
+  public void setIncognito(WebView view, boolean enabled) {
+    // Remove all previous cookies
+    CookieManager.getInstance().removeAllCookies(null);
+
+    // Disable caching
+    view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
+    view.getSettings().setAppCacheEnabled(!enabled);
+    view.clearHistory();
+    view.clearCache(enabled);
+
+    // No form data or autofill enabled
+    view.clearFormData();
+    view.getSettings().setSavePassword(!enabled);
+    view.getSettings().setSaveFormData(!enabled);
+  }
 
   @ReactProp(name = "source")
   public void setSource(WebView view, @Nullable ReadableMap source) {

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -831,9 +831,9 @@ If true, this will be able horizontal swipe gestures when using the WKWebView. T
 
 Does not store any data within the lifetime of the WebView.
 
-| Type    | Required | Platform      |
-| ------- | -------- | ------------- |
-| boolean | No       | iOS WKWebView |
+| Type    | Required | Platform               |
+| ------- | -------- | ---------------------- |
+| boolean | No       | Android, iOS WKWebView |
 
 ---
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -212,6 +212,7 @@ export type OnShouldStartLoadWithRequest = (
 
 export interface CommonNativeWebViewProps extends ViewProps {
   cacheEnabled?: boolean;
+  incognito?: boolean;
   injectedJavaScript?: string;
   mediaPlaybackRequiresUserAction?: boolean;
   messagingEnabled: boolean;
@@ -258,7 +259,6 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   decelerationRate?: number;
   directionalLockEnabled?: boolean;
   hideKeyboardAccessoryView?: boolean;
-  incognito?: boolean;
   pagingEnabled?: boolean;
   scrollEnabled?: boolean;
   useSharedProcessPool?: boolean;


### PR DESCRIPTION
Allows the webview to be opened with an ephemeral data storage.

Follow-up to https://github.com/react-native-community/react-native-webview/pull/148.

Closes https://github.com/react-native-community/react-native-webview/issues/737