### PR TITLE
wrap WebViewProgressEvent into NativeSyntheticEvent

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -91,7 +91,7 @@ export interface WebViewNativeEvent {
   lockIdentifier: number;
 }
 
-export interface WebViewProgressEvent extends WebViewNativeEvent {
+export interface WebViewNativeProgressEvent extends WebViewNativeEvent {
   progress: number;
 }
 
@@ -121,6 +121,8 @@ export interface WebViewError extends WebViewNativeEvent {
 }
 
 export type WebViewEvent = NativeSyntheticEvent<WebViewNativeEvent>;
+
+export type WebViewProgressEvent = NativeSyntheticEvent<WebViewNativeProgressEvent>;
 
 export type WebViewNavigationEvent = NativeSyntheticEvent<WebViewNavigation>;
 


### PR DESCRIPTION
`onLoadingProgress(event: WebViewProgressEvent)` uses wrong parameter type. 

It uses `WebViewProgressEvent` but should use  `NativeSyntheticEvent<WebViewProgressEvent>,` similar to `WebViewEvent`.

If you use the typescript definition as implement like:

```
private onLoadProgress(event: WebViewProgressEvent) {
        this.setState({ loadingProgress: event.progress });
}
```

`event.progress` is always `undefined`. You can use the progress with `event.nativeEvent.progress` but then you will get a typescript error.