### PR TITLE
feat(WKWebView): Allow focus without user interaction

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -42,6 +42,7 @@ This document lays out the current public properties and methods for the React N
 - [`useWebKit`](Reference.md#usewebkit)
 - [`url`](Reference.md#url)
 - [`html`](Reference.md#html)
+- [`keyboardDisplayRequiresUserAction`](Reference.md#keyboardDisplayRequiresUserAction)
 - [`hideKeyboardAccessoryView`](Reference.md#hidekeyboardaccessoryview)
 - [`allowsBackForwardNavigationGestures`](Reference.md#allowsbackforwardnavigationgestures)
 - [`incognito`](Reference.md#incognito)
@@ -753,6 +754,16 @@ If true, use WKWebView instead of UIWebView.
 | Type   | Required |
 | ------ | -------- |
 | string | No       |
+
+---
+
+### `keyboardDisplayRequiresUserAction`
+
+If false, web content can programmatically display the keyboard when using the WKWebView. The default value is `true`.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS      |
 
 ---
 

--- a/ios/RNCWKWebView.h
+++ b/ios/RNCWKWebView.h
@@ -37,6 +37,7 @@
 #endif
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
+@property (nonatomic, assign) BOOL keyboardDisplayRequiresUserAction;
 @property (nonatomic, assign) BOOL hideKeyboardAccessoryView;
 @property (nonatomic, assign) BOOL allowsBackForwardNavigationGestures;
 @property (nonatomic, assign) BOOL incognito;

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -41,6 +41,7 @@ static NSURLCredential* clientAuthenticationCredential;
 {
   UIColor * _savedBackgroundColor;
   BOOL _savedHideKeyboardAccessoryView;
+  BOOL _savedKeyboardDisplayRequiresUserAction;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -214,6 +215,7 @@ static NSURLCredential* clientAuthenticationCredential;
 
     [self addSubview:_webView];
     [self setHideKeyboardAccessoryView: _savedHideKeyboardAccessoryView];
+    [self setKeyboardDisplayRequiresUserAction: _savedKeyboardDisplayRequiresUserAction];
     [self visitSource];
   }
 }
@@ -362,6 +364,64 @@ static NSURLCredential* clientAuthenticationCredential;
     else {
         [_webView loadFileURL:request.URL allowingReadAccessToURL:request.URL];
     }
+}
+
+-(void)setKeyboardDisplayRequiresUserAction:(BOOL)keyboardDisplayRequiresUserAction
+{
+    if (_webView == nil) {
+        _savedKeyboardDisplayRequiresUserAction = keyboardDisplayRequiresUserAction;
+        return;
+    }
+  
+    if (_savedKeyboardDisplayRequiresUserAction == true) {
+        return;
+    }
+  
+    UIView* subview;
+  
+    for (UIView* view in _webView.scrollView.subviews) {
+        if([[view.class description] hasPrefix:@"WK"])
+            subview = view;
+    }
+  
+    if(subview == nil) return;
+  
+    Class class = subview.class;
+  
+    NSOperatingSystemVersion iOS_11_3_0 = (NSOperatingSystemVersion){11, 3, 0};
+    NSOperatingSystemVersion iOS_12_2_0 = (NSOperatingSystemVersion){12, 2, 0};
+
+    Method method;
+    IMP override;
+  
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_12_2_0]) {
+        // iOS 12.2.0 - Future
+        SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
+        method = class_getInstanceMethod(class, selector);
+        IMP original = method_getImplementation(method);
+        override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+            ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
+        });
+    }
+    else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_11_3_0]) {
+        // iOS 11.3.0 - 12.2.0
+        SEL selector = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
+        method = class_getInstanceMethod(class, selector);
+        IMP original = method_getImplementation(method);
+        override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+            ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
+        });
+    } else {
+        // iOS 9.0 - 11.3.0
+        SEL selector = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:userObject:");
+        method = class_getInstanceMethod(class, selector);
+        IMP original = method_getImplementation(method);
+        override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, id arg3) {
+            ((void (*)(id, SEL, void*, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3);
+        });
+    }
+  
+    method_setImplementation(method, override);
 }
 
 -(void)setHideKeyboardAccessoryView:(BOOL)hideKeyboardAccessoryView

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -55,6 +55,7 @@ static NSURLCredential* clientAuthenticationCredential;
     _directionalLockEnabled = YES;
     _automaticallyAdjustContentInsets = YES;
     _contentInset = UIEdgeInsetsZero;
+    _savedKeyboardDisplayRequiresUserAction = YES;
   }
 
   // Workaround for a keyboard dismissal bug present in iOS 12

--- a/ios/RNCWKWebViewManager.m
+++ b/ios/RNCWKWebViewManager.m
@@ -43,7 +43,6 @@ RCT_EXPORT_VIEW_PROPERTY(dataDetectorTypes, WKDataDetectorTypes)
 #endif
 RCT_EXPORT_VIEW_PROPERTY(contentInset, UIEdgeInsets)
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustContentInsets, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(keyboardDisplayRequiresUserAction, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideKeyboardAccessoryView, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsBackForwardNavigationGestures, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(incognito, BOOL)
@@ -100,6 +99,10 @@ RCT_CUSTOM_VIEW_PROPERTY(showsHorizontalScrollIndicator, BOOL, RNCWKWebView) {
 
 RCT_CUSTOM_VIEW_PROPERTY(showsVerticalScrollIndicator, BOOL, RNCWKWebView) {
   view.showsVerticalScrollIndicator = json == nil ? true : [RCTConvert BOOL: json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(keyboardDisplayRequiresUserAction, BOOL, RNCWKWebView) {
+  view.keyboardDisplayRequiresUserAction = json == nil ? true : [RCTConvert BOOL: json];
 }
 
 RCT_EXPORT_METHOD(injectJavaScript:(nonnull NSNumber *)reactTag script:(NSString *)script)

--- a/ios/RNCWKWebViewManager.m
+++ b/ios/RNCWKWebViewManager.m
@@ -43,6 +43,7 @@ RCT_EXPORT_VIEW_PROPERTY(dataDetectorTypes, WKDataDetectorTypes)
 #endif
 RCT_EXPORT_VIEW_PROPERTY(contentInset, UIEdgeInsets)
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustContentInsets, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(keyboardDisplayRequiresUserAction, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hideKeyboardAccessoryView, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsBackForwardNavigationGestures, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(incognito, BOOL)

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -401,6 +401,18 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    */
   directionalLockEnabled?: boolean;
 
+  /**
+   * A Boolean value indicating whether web content can programmatically display the keyboard.
+   *
+   * When this property is set to true, the user must explicitly tap the elements in the
+   * web view to display the keyboard (or other relevant input view) for that element.
+   * When set to false, a focus event on an element causes the input view to be displayed
+   * and associated with that element automatically.
+   *
+   * The default value is `true`.
+   * @platform ios
+   */
+  keyboardDisplayRequiresUserAction?: boolean;
 }
 
 export interface AndroidWebViewProps extends WebViewSharedProps {


### PR DESCRIPTION
## Summary
This is an attempt at solving https://github.com/react-native-community/react-native-webview/issues/278 for iOS. It introduces a new prop called `keyboardDisplayRequiresUserAction`. Setting it to `false` will allow the WebView to bring up the keyboard on focus events. It works on 9.0-12.2. It works by swizzling WKContentView, with different versions for the 11.3-12.20+ ranges.

## Testing strategy
Created a new app using react-native init using my modified version, setting `https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_text_autofocus` as the source. When set to false, it would autofocus, when set to true it didn't. I also tried combining it with `hideKeyboardAccessoryView` which also swizzles, and all combinations worked fine.

Please let me know what else needs to be done, such as updating docs? Should I also update the UIWebView version? I don't have a lot of expertise in Android, but am happy to tackle that maybe next.