### PR TITLE
 Fix unable to re-enable hardware acceleration after disabled it

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -290,6 +290,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   public void setHardwareAccelerationDisabled(WebView view, boolean disabled) {
     if (disabled) {
       view.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+    } else {
+      view.setLayerType(View.LAYER_TYPE_NONE, null);
     }
   }
 


### PR DESCRIPTION
After changed the props "androidHardwareAccelerationDisabled" to false, changing it to back to true will not re-enable hardware acceleration in Android