### PR TITLE
Adds guide for intercepting hash URL changes

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -369,6 +369,8 @@ title
 url
 ```
 
+Note that this method will not be invoked on hash URL changes (e.g. from `https://example.com/users#list` to `https://example.com/users#help`). There is a workaround for this that is described [in the Guide](Guide.md#intercepting-hash-url-changes).
+
 ---
 
 ### `originWhitelist`


### PR DESCRIPTION
Per @janicduplessis's [comment](https://github.com/react-native-community/react-native-webview/issues/24#issuecomment-483956651) on issue #24, there's a decent workaround to capturing hash URL changes. I've added this to the Guide.md file.

There are a bunch of Prettier updates as well. We should probably run Prettier on the whole project and add `lint-staged` and `husky` to avoid this issue in the future. I'll work on that if @Titozzz agrees.