### PR TITLE
fix Java syntax error

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -449,7 +449,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
     export.put(TopLoadingProgressEvent.EVENT_NAME, MapBuilder.of("registrationName", "onLoadingProgress"));
     export.put(TopShouldStartLoadWithRequestEvent.EVENT_NAME, MapBuilder.of("registrationName", "onShouldStartLoadWithRequest"));
-    export.put(ScrollEventType.SCROLL.getJSEventName(), MapBuilder.of("registrationName", "onScroll"));
+    export.put(ScrollEventType.getJSEventName(ScrollEventType.SCROLL), MapBuilder.of("registrationName", "onScroll"));
     return export;
   }
 


### PR DESCRIPTION
`getJSEventName()` needs a ScrollEventType parameter.

```java
public static String getJSEventName(ScrollEventType type) {
    switch (type) {
      case BEGIN_DRAG:
        return "topScrollBeginDrag";
      case END_DRAG:
        return "topScrollEndDrag";
      case SCROLL:
        return "topScroll";
      case MOMENTUM_BEGIN:
        return "topMomentumScrollBegin";
      case MOMENTUM_END:
        return "topMomentumScrollEnd";
      default:
        throw new IllegalArgumentException("Unsupported ScrollEventType: " + type);
    }
  }
```