### PR TITLE
fix(AndroidX support): Fixed broken import + added instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This project follows [semantic versioning](https://semver.org/). We do not hesit
 
 Current Version: ![version](https://img.shields.io/npm/v/react-native-webview.svg)
 
+- [6.0.**2**](https://github.com/react-native-community/react-native-webview/releases/tag/v6.0.2) - Update to AndroidX. Make sure to enable it in your project's `android/gradle.properties`. See [Getting Started Guide](docs/Getting-Started.md).
 - [5.0.**1**](https://github.com/react-native-community/react-native-webview/releases/tag/v5.0.0) - Refactored the old postMessage implementation for communication from webview to native.
 - [4.0.0](https://github.com/react-native-community/react-native-webview/releases/tag/v4.0.0) - Added cache (enabled by default).
 - [3.0.0](https://github.com/react-native-community/react-native-webview/releases/tag/v3.0.0) - WKWebview: Add shared process pool so cookies and localStorage are shared across webviews in iOS (enabled by default).

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,3 @@ ReactNativeWebView_kotlinVersion=1.3.11
 ReactNativeWebView_compileSdkVersion=28
 ReactNativeWebView_buildToolsVersion=28.0.3
 ReactNativeWebView_targetSdkVersion=28
-android.useAndroidX=true

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -10,7 +10,7 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
-import android.support.annotation.RequiresApi;
+import androidx.annotation.RequiresApi;
 import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.View;

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -18,6 +18,7 @@ $ react-native link react-native-webview
 
 iOS:
 This module does not require any extra step after running the link command 🎉
+
 Android:
 Please make sure AndroidX is enabled in your project by editting `android/gradle.properties` and adding 2 lines:
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -12,10 +12,20 @@ $ yarn add react-native-webview
 
 React Native modules that include native Objective-C, Swift, Java, or Kotlin code have to be "linked" so that the compiler knows to include them in the app.
 
-This module does not require any extra step after running the link command 🎉
 ```
 $ react-native link react-native-webview
 ```
+
+iOS:
+This module does not require any extra step after running the link command 🎉
+Android:
+Please make sure AndroidX is enabled in your project by editting `android/gradle.properties` and adding 2 lines:
+
+```
+android.useAndroidX=true
+android.enableJetifier=true
+```
+
 For Android manual installation, please refer to [this article](https://engineering.brigad.co/demystifying-react-native-modules-linking-964399ec731b) where you can find detailed step on how to link any react-native project.
 
 For iOS, while you can manually link the old way using [react-native own tutorial](https://facebook.github.io/react-native/docs/linking-libraries-ios), we find it easier to use cocoapods.
@@ -33,8 +43,8 @@ class MyWeb extends Component {
   render() {
     return (
       <WebView
-        source={{uri: 'https://infinite.red'}}
-        style={{marginTop: 20}}
+        source={{ uri: 'https://infinite.red' }}
+        style={{ marginTop: 20 }}
       />
     );
   }


### PR DESCRIPTION
Hello, in order to use react-native-webview > 6.0.0 please make your android/build.gradle contains:
```
android.useAndroidX=true
android.enableJetifier=true
```
This enables AndroidX libraries which are the new standard.