### PR TITLE
Remove hardcoded white backgroundColor

### DIFF
--- a/src/WebView.styles.ts
+++ b/src/WebView.styles.ts
@@ -46,7 +46,7 @@ const styles = StyleSheet.create<Styles>({
     marginBottom: 10,
   },
   webView: {
-    backgroundColor: '#ffffff',
+  
   },
 });
 


### PR DESCRIPTION
I need my webview to have transparent backgroundColor.
(My webview displays augmented reality content on top of a video)
I have tried:
<WebView style = {{backgroundColor: "transparent"}}>
and 
<WebView backgroundColor = {"transparent"}> 
but none of them work, it is always white because of this hardcoded white backgroundColor.

When I remove the hardcoded white line from the styles file, I can select whatever color I need with the backgroundColor property, also transparent.
( Tested on version 5.9.1 )

## Compatibility
| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
