### PR TITLE
fix(types): Add missing applicationNameForUserAgent type

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -376,6 +376,13 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   useSharedProcessPool?: boolean;
+
+  /**
+   * Append to the existing user-agent. Overriden if `userAgent` is set.
+   * @platform ios
+   */
+  applicationNameForUserAgent?: string;
+
   /**
    * The custom user agent string.
    */


### PR DESCRIPTION
Followup to https://github.com/react-native-community/react-native-webview/pull/506 