### PR TITLE
add-javascriptEnabled-in-IOS

### DIFF
--- a/ios/RNCWKWebView.h
+++ b/ios/RNCWKWebView.h
@@ -45,6 +45,7 @@
 @property (nonatomic, copy) NSString *userAgent;
 @property (nonatomic, copy) NSString *applicationNameForUserAgent;
 @property (nonatomic, assign) BOOL cacheEnabled;
+@property (nonatomic, assign) BOOL javaScriptEnabled;
 @property (nonatomic, assign) BOOL allowsLinkPreview;
 @property (nonatomic, assign) BOOL showsHorizontalScrollIndicator;
 @property (nonatomic, assign) BOOL showsVerticalScrollIndicator;

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -107,6 +107,11 @@ static NSURLCredential* clientAuthenticationCredential;
 {
   if (self.window != nil && _webView == nil) {
     WKWebViewConfiguration *wkWebViewConfig = [WKWebViewConfiguration new];
+    WKPreferences *prefs = [[WKPreferences alloc]init];
+    if(!_javascriptEnabled) {
+      prefs.javaScriptEnabled = NO;
+      vwkWebViewConfig.preferences = prefs;
+    }
     if (_incognito) {
       wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
     } else if (_cacheEnabled) {

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -64,6 +64,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
   static defaultProps = {
     useWebKit: true,
     cacheEnabled: true,
+    javaScriptEnabled: true,
     originWhitelist: defaultOriginWhitelist,
     useSharedProcessPool: true,
   };


### PR DESCRIPTION

# Summary

When opening Google Docs in the IOS WebView
If JavaScriptEnabled is true, Google Docs will have a header.
There is also a page called Clear the cache and the cookies.

I fixed this problem by adding javaScriptEnabled to IOS.

One javaScriptEnabled variable and five lines of code have been added.

I used javaScriptEnabled in WKPreferences.

In addition to the issues I mentioned, you can solve problems that occur when iOS can not use javaScriptEnabled as false.


## Test Plan

Just add 5 lines to RNCWKWebView.m.

WKPreferences * prefs = [[WKPreferences alloc] init];
     if (! _ javascriptEnabled) {
       prefs.javaScriptEnabled = NO;
       wkWebViewConfig.preferences = prefs;
     }

The simplest test is to open Google Docs with WebView in IOS.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
