### PR TITLE
add-javaScriptEnabled-in-IOS

### DIFF
--- a/ios/RNCWKWebView.h
+++ b/ios/RNCWKWebView.h
@@ -45,6 +45,7 @@
 @property (nonatomic, copy) NSString *userAgent;
 @property (nonatomic, copy) NSString *applicationNameForUserAgent;
 @property (nonatomic, assign) BOOL cacheEnabled;
+@property (nonatomic, assign) BOOL javaScriptEnabled;
 @property (nonatomic, assign) BOOL allowsLinkPreview;
 @property (nonatomic, assign) BOOL showsHorizontalScrollIndicator;
 @property (nonatomic, assign) BOOL showsVerticalScrollIndicator;

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -107,6 +107,11 @@ static NSURLCredential* clientAuthenticationCredential;
 {
   if (self.window != nil && _webView == nil) {
     WKWebViewConfiguration *wkWebViewConfig = [WKWebViewConfiguration new];
+    WKPreferences *prefs = [[WKPreferences alloc]init];
+    if (!_javaScriptEnabled) {
+      prefs.javaScriptEnabled = NO;
+      wkWebViewConfig.preferences = prefs;
+    }
     if (_incognito) {
       wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
     } else if (_cacheEnabled) {

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -63,6 +63,7 @@ const RNCWKWebView: typeof NativeWebViewIOS = requireNativeComponent(
 class WebView extends React.Component<IOSWebViewProps, State> {
   static defaultProps = {
     useWebKit: true,
+    javaScriptEnabled: true,
     cacheEnabled: true,
     originWhitelist: defaultOriginWhitelist,
     useSharedProcessPool: true,

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -478,13 +478,6 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
   urlPrefixesForDefaultIntent?: ReadonlyArray<string>;
 
   /**
-   * Boolean value to enable JavaScript in the `WebView`. Used on Android only
-   * as JavaScript is enabled by default on iOS. The default value is `true`.
-   * @platform android
-   */
-  javaScriptEnabled?: boolean;
-
-  /**
    * Boolean value to disable Hardware Acceleration in the `WebView`. Used on Android only
    * as Hardware Acceleration is a feature only for Android. The default value is `false`.
    * @platform android
@@ -542,6 +535,13 @@ export interface WebViewSharedProps extends ViewProps {
    */
   source?: WebViewSource;
 
+  /**
+   * Boolean value to enable JavaScript in the `WebView`. Used on Android only
+   * as JavaScript is enabled by default on iOS. The default value is `true`.
+   * @platform android
+   */
+  javaScriptEnabled?: boolean;
+  
   /**
    * Function that returns a view to show if there's an error.
    */


### PR DESCRIPTION
# Summary
When opening Google Docs in the IOS WebView
If `JavaScriptEnabled` is true, Google Docs will have a header.
There is also a page called Clear the cache and the cookies.

I fixed this problem by adding `javaScriptEnabled` to IOS.

One `javaScriptEnabled` variable and five lines of code have been added.

I used javaScriptEnabled in `WKPreferences`.

In addition to the issues I mentioned, you can solve problems that occur when iOS can not use `javaScriptEnabled` as false.

## Test Plan

Just add 5 lines to RNCWKWebView.m.

```
WKPreferences * prefs = [[WKPreferences alloc] init];
     if (! _ javascriptEnabled) {
       prefs.javaScriptEnabled = NO;
       wkWebViewConfig.preferences = prefs;
     }
```

The simplest test is to open Google Docs with WebView in IOS.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [x] I updated the typed files (TS and Flow)
