### PR TITLE
Fix CSS rendering bug when using startInLoadingState

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -244,13 +244,6 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     }
 
     const webViewStyles = [styles.container, styles.webView, style];
-    if (
-      this.state.viewState === 'LOADING'
-      || this.state.viewState === 'ERROR'
-    ) {
-      // if we're in either LOADING or ERROR states, don't show the webView
-      webViewStyles.push(styles.hidden);
-    }
 
     if (source && 'method' in source) {
       if (source.method === 'POST' && source.headers) {

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -346,13 +346,6 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     }
 
     const webViewStyles = [styles.container, styles.webView, style];
-    if (
-      this.state.viewState === 'LOADING'
-      || this.state.viewState === 'ERROR'
-    ) {
-      // if we're in either LOADING or ERROR states, don't show the webView
-      webViewStyles.push(styles.hidden);
-    }
 
     const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
       this.onShouldStartLoadWithRequestCallback,

--- a/src/WebView.styles.ts
+++ b/src/WebView.styles.ts
@@ -2,11 +2,9 @@ import { StyleSheet, ViewStyle, TextStyle } from 'react-native';
 
 interface Styles {
   container: ViewStyle;
-  errorContainer: ViewStyle;
   errorText: TextStyle;
   errorTextTitle: TextStyle;
-  hidden: ViewStyle;
-  loadingView: ViewStyle;
+  loadingOrErrorView: ViewStyle;
   webView: ViewStyle;
   loadingProgressBar: ViewStyle;
 }
@@ -16,21 +14,14 @@ const styles = StyleSheet.create<Styles>({
     flex: 1,
     overflow: 'hidden',
   },
-  errorContainer: {
+  loadingOrErrorView: {
+    position: 'absolute',
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'white',
-  },
-  hidden: {
-    height: 0,
-    flex: 0, // disable 'flex:1' when hiding a View
-  },
-  loadingView: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'white',
+    height: '100%',
+    width: '100%',
+    backgroundColor: 'white'
   },
   loadingProgressBar: {
     height: 20,

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -75,7 +75,7 @@ const getViewManagerConfig = (
 };
 
 const defaultRenderLoading = () => (
-  <View style={styles.loadingView}>
+  <View style={styles.loadingOrErrorView}>
     <ActivityIndicator />
   </View>
 );
@@ -84,7 +84,7 @@ const defaultRenderError = (
   errorCode: number,
   errorDesc: string,
 ) => (
-  <View style={styles.errorContainer}>
+  <View style={styles.loadingOrErrorView}>
     <Text style={styles.errorTextTitle}>Error loading page</Text>
     <Text style={styles.errorText}>{`Domain: ${errorDomain}`}</Text>
     <Text style={styles.errorText}>{`Error Code: ${errorCode}`}</Text>


### PR DESCRIPTION
I am using react-native-weview on an app, and it works very well. But, when I introduced a custom loading screen, I noticed a very odd bug in the application of CSS to the webpage inside the webview. This is best explained via screenshots: 

Before using `startInLoadingState={true}`
<img width="371" alt="image" src="https://user-images.githubusercontent.com/368961/58655494-341f4980-82e8-11e9-98b3-3fc97d9499f6.png">

After using `startInLoadingState={true}`
<img width="375" alt="image" src="https://user-images.githubusercontent.com/368961/58655382-fcb09d00-82e7-11e9-8424-547262da4854.png">

Notice that the bar at the bottom of the webview has a blur effect in the first screenshot, but no blur effect in the second screenshot. The css applied to the underlying site has not changed. To reproduce, load a webpage in the webview with an element that has `-webkit-backdrop-filter: blur(20px);` and something colorful behind it (so you can see the blur effect). The URL of the page in the screenshot is `https://review.discourse.org`. 

The source of the issue is that when using `startInLoadingState={true}`, the webview initially is hidden (`width: 0; flex: 0`) and then shown, and this trips up the renderer. Switching to positioning the loading/error views absolutely fixes the issue. 

The styles for the error view and loading view are identical, so this PR merges them into one `loadingOrErrorView` style. 