### PR TITLE
fixes the problem of tag <input type='file'> without attribute accept…

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -282,7 +282,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
 
   private Boolean acceptsImages(String[] types) {
     String[] mimeTypes = getAcceptedMimeType(types);
-    return isArrayEmpty(mimeTypes) || arrayContainsString(mimeTypes, "image");
+    return isArrayEmpty(mimeTypes) || arrayContainsString(mimeTypes, "image") || arrayContainsString(mimeTypes,"*/*"); //mimeTypes is never really empty it has */* in it if webpage input="file" does not have tag 'accept="image/*"'
   }
 
   private Boolean acceptsVideo(String types) {
@@ -295,7 +295,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
 
   private Boolean acceptsVideo(String[] types) {
     String[] mimeTypes = getAcceptedMimeType(types);
-    return isArrayEmpty(mimeTypes) || arrayContainsString(mimeTypes, "video");
+    return isArrayEmpty(mimeTypes) || arrayContainsString(mimeTypes, "image") || arrayContainsString(mimeTypes,"*/*"); //mimeTypes is never really empty it has */* in it if webpage input="file" does not have tag 'accept="image/*"'
   }
 
   private Boolean arrayContainsString(String[] array, String pattern) {


### PR DESCRIPTION
…=' not allowing user to choose to take a picture or video with the camera. Before it only allowed file upload without explicitly declaring the mime types in accept attribute now it will allow the option of taking picture or video as most browsers do.  Can be tested at: https://andreipfeiffer.github.io/react-native-webview-android-file-upload/index.html

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:
Needed ability to access camera or video on <input type="file>  without the 'accepts' attribute being set to something like "image/*".  Former behavor does not match most web browsers in stand alone.  

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution? Test for */* which is in the array.. the array is not empty as expected by the code.

* What areas of the library does it impact?
-->
file upload

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |   /not necessary i think
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
