### PR TITLE
Switch from `prepack` to `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci:publish": "yarn semantic-release",
     "lint": "yarn tsc --noEmit && yarn eslint ./src --ext .ts,.tsx",
     "build": "yarn tsc",
-    "prepack": "yarn build",
+    "prepare": "yarn build",
     "test": "yarn jest"
   },
   "peerDependencies": {


### PR DESCRIPTION
# Summary

As described in the [NPM documentation](https://docs.npmjs.com/misc/scripts#prepublish-and-prepare), the `prepare` script should be used for essential build tasks.

In practice, this makes it possible to depend on `react-native-webview` via git. If I contribute a new feature, I can use the feature right away by depending on its git branch, without waiting for upstream to publish, or even approve my pull request. This is great for experimentation.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

## Test Plan

Verify that existing features still work:

- [x] `yarn` install still generates the `lib/` folder.
- [x] `npm install` still generates the `lib/` folder.
- [x] `npm publish --dry-run` still generates the `lib/` folder.
- [x] `yarn publish` still generates the `lib/` folder.

Verify that new features work:

- [x] `yarn add git://github.com/swansontec/react-native-webview#use-prepare-script` in a fresh project now generates `node_modules/react-native-webview/lib`.
- [x] `npm install git://github.com/swansontec/react-native-webview#use-prepare-script` in a fresh project now generates `node_modules/react-native-webview/lib`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)

This project does not have a `CHANGELOG.md` file! Also, none of the other steps are applicable to this change.