### PR TITLE
Fix: Flex loading view

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -243,7 +243,12 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
       );
     }
 
-    const webViewStyles = [styles.container, styles.webView, style];
+    const webViewStyles = [
+      styles.container,
+      styles.webView,
+      style,
+      this.state.viewState === 'LOADING' && styles.webViewLoading,
+    ];
 
     if (source && 'method' in source) {
       if (source.method === 'POST' && source.headers) {

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -345,7 +345,12 @@ class WebView extends React.Component<IOSWebViewProps, State> {
       );
     }
 
-    const webViewStyles = [styles.container, styles.webView, style];
+    const webViewStyles = [
+      styles.container,
+      styles.webView,
+      style,
+      this.state.viewState === 'LOADING' && styles.webViewLoading,
+    ];
 
     const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
       this.onShouldStartLoadWithRequestCallback,

--- a/src/WebView.styles.ts
+++ b/src/WebView.styles.ts
@@ -6,6 +6,7 @@ interface Styles {
   errorTextTitle: TextStyle;
   loadingOrErrorView: ViewStyle;
   webView: ViewStyle;
+  webViewLoading: ViewStyle;
   loadingProgressBar: ViewStyle;
 }
 
@@ -38,6 +39,9 @@ const styles = StyleSheet.create<Styles>({
   },
   webView: {
     backgroundColor: '#ffffff',
+  },
+  webViewLoading: {
+    flex: 0,
   },
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When web content is loading, let the loading view flex the entire container space. After migrating to react-native-webview (from react-native core WebView), loading view only occupies half of the container.

## Test Plan

This was tested on iOS simulator

| Before fix | After fix |
|-------|------|
| ![before-ios mov](https://user-images.githubusercontent.com/309515/59885880-a4623d80-9371-11e9-9edd-fa85cd3f60e4.gif) | ![after-ios mov](https://user-images.githubusercontent.com/309515/59885885-a9bf8800-9371-11e9-99b2-d49fc800f70d.gif) |

### What's required for testing (prerequisites)?
Given an empty react-native app with react-native-webview linked, and the following root component:

```js

export default class App extends Component<Props> {
  static renderLoading = () => (
    <View style={styles.loading}>
      <Text style={styles.loadingText}>LOADING...</Text>
    </View>
  );

  render() {
    return (
      <SafeAreaView style={styles.container}>
        <WebView
          renderLoading={App.renderLoading}
          source={{ uri: "https://facebook.github.io/react-native/" }}
          startInLoadingState
          style={styles.webview}
        />
      </SafeAreaView>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1
  },
  webview: {
    flex: 1
  },
  loading: {
    backgroundColor: "green",
    flex: 1,
    alignItems: "center",
    flexDirection: "row",
    justifyContent: "center"
  },
  loadingText: {
    color: "red"
  }
});
```

### What are the steps to reproduce (after prerequisites)?

Run the app and observe loading view rendering

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |  ✅    |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)