### PR TITLE
Update Expo support state in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _This project is maintained for free by these people using both their free time 
 - [x] iOS (both UIWebView and WKWebView)
 - [x] Android
 
-_Note: Expo support for React Native WebView is start from [Expo SDK v33.0.0](https://blog.expo.io/expo-sdk-v33-0-0-is-now-available-52d1c99dfe4c)._
+_Note: Expo support for React Native WebView started with [Expo SDK v33.0.0](https://blog.expo.io/expo-sdk-v33-0-0-is-now-available-52d1c99dfe4c)._
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _This project is maintained for free by these people using both their free time 
 - [x] iOS (both UIWebView and WKWebView)
 - [x] Android
 
-_Note: React Native WebView is not currently supported by Expo unless you "eject"._
+_Note: Expo support for React Native WebView is start from [Expo SDK v33.0.0](https://blog.expo.io/expo-sdk-v33-0-0-is-now-available-52d1c99dfe4c)._
 
 ## Getting Started
 


### PR DESCRIPTION

# Summary

Expo SDK 33 is now use React Native WebView https://blog.expo.io/expo-sdk-v33-0-0-is-now-available-52d1c99dfe4c

update the support state in README

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
