### PR TITLE
Add explicit SSL error handling to RNCWebViewClient (Android)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.net.http.SslError;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -22,6 +23,7 @@ import android.webkit.CookieManager;
 import android.webkit.DownloadListener;
 import android.webkit.GeolocationPermissions;
 import android.webkit.JavascriptInterface;
+import android.webkit.SslErrorHandler;
 import android.webkit.URLUtil;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
@@ -637,6 +639,50 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       return this.shouldOverrideUrlLoading(view, url);
     }
 
+    @Override
+    public void onReceivedSslError(final WebView webView, final SslErrorHandler handler, final SslError error) {
+        handler.cancel();
+
+        int code = error.getPrimaryError();
+        String failingUrl = error.getUrl();
+        String description = "";
+
+        // https://developer.android.com/reference/android/net/http/SslError.html
+        switch (code) {
+          case SslError.SSL_DATE_INVALID:
+            description = "The date of the certificate is invalid";
+            break;
+          case SslError.SSL_EXPIRED:
+            description = "The certificate has expired";
+            break;
+          case SslError.SSL_IDMISMATCH:
+            description = "Hostname mismatch";
+            break;
+          case SslError.SSL_INVALID:
+            description = "A generic error occurred";
+            break;
+          case SslError.SSL_MAX_ERROR:
+            description = "The number of different SSL errors.";
+            break;
+          case SslError.SSL_NOTYETVALID:
+            description = "The certificate is not yet valid";
+            break;
+          case SslError.SSL_UNTRUSTED:
+            description = "The certificate authority is not trusted";
+            break;
+          default: 
+            description = "Unknown SSL Error";
+            break;
+        }
+
+        this.onReceivedError(
+          webView,
+          code,
+          description,
+          failingUrl
+        );
+    }
+    
     @Override
     public void onReceivedError(
       WebView webView,


### PR DESCRIPTION
# Summary

On android the JS `react-native-webview` WebView was not calling `onError` event or `renderError` when visiting a site with an invalid SSL certificate. Leaving the page blank.

This PR adds explicit handling to SSL errors by overriding 

```java
 public void onReceivedSslError(final WebView webView, final SslErrorHandler handler, final SslError error) {
```

In the [RNCWebViewManager.java -> RNCWebViewClient](https://github.com/react-native-community/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java#L591)

It uses descriptions from error code provided here [https://developer.android.com/reference/android/net/http/SslError.html](https://developer.android.com/reference/android/net/http/SslError.html)

This should have minimal impact, and should not affect any custom implementations. 

Possibly relates to https://github.com/react-native-community/react-native-webview/issues/259

## Test Plan

### What's required for testing (prerequisites)?
- Setup a WebView
```javascript
import { WebView } from 'react-native-webview'
...
<WevView
  onError={({ nativeEvent }) => {
    alert(JSON.stringify(nativeEvent, null, 2))
  }}
/>
```
- On android navigate to site with invalid certificate. 

<img width="338" alt="Screen Shot 2019-06-23 at 9 45 59 AM" src="https://user-images.githubusercontent.com/3740088/59977845-d0610700-959b-11e9-90e9-70b127fca9b5.png">


## Compatibility

| OS         | Implemented |
| ------- | :------------: |
| Android |    ✅              |

### Note: Not sure how to set this to also get this applied to the 5.x branch, guidance appreciated.

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)