### PR TITLE
Align look and feel of Window.prompt() to Mobile Safari

### DIFF
--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -643,12 +643,17 @@ static NSURLCredential* clientAuthenticationCredential;
 - (void)webView:(WKWebView *)webView runJavaScriptTextInputPanelWithPrompt:(NSString *)prompt defaultText:(NSString *)defaultText initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSString *))completionHandler{
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"" message:prompt preferredStyle:UIAlertControllerStyleAlert];
     [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
-        textField.textColor = [UIColor lightGrayColor];
-        textField.placeholder = defaultText;
+        textField.text = defaultText;
     }];
-    [alert addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
         completionHandler([[alert.textFields lastObject] text]);
-    }]];
+    }];
+    [alert addAction:okAction];
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+        completionHandler(nil);
+    }];
+    [alert addAction:cancelAction];
+    alert.preferredAction = okAction;
     [[self topViewController] presentViewController:alert animated:YES completion:NULL];
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When calling `window.prompt(text, defaultText)` on iOS, `react-native-webview` doesn't render the cancel button. Also `defaultText` is incorrectly set to the placeholder text which disappears once the user starts typing.  

This issue does not affect Android. 

**Desired behaviour as comparing to Mobile Safari**
![image](https://user-images.githubusercontent.com/7780775/60141493-d825e300-9809-11e9-8477-ad5d663ff154.png)

**Existing behaviour**
![image](https://user-images.githubusercontent.com/7780775/60141504-e3790e80-9809-11e9-964c-1b72c6bcbe41.png)

**After the fix**
![image](https://user-images.githubusercontent.com/7780775/60141514-ea078600-9809-11e9-80a1-af84787ddc7f.png)


## Test Plan

Render

`<WebView source={{ uri: 'https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_prompt' }} />`

And click on the "Try it" button.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

This issue does not affect Android. 

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
