### PR TITLE
Add pod install step to getting started guide

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -23,7 +23,11 @@ $ react-native link react-native-webview
 ```
 
 iOS:
-This module does not require any extra step after running the link command 🎉
+
+If using cocoapods in the `ios/` directory run
+```
+$ pod install
+```
 
 Android - react-native-webview version <6:
 This module does not require any extra step after running the link command 🎉


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
I believe the getting started guide leaves out that you need to run `pod install` after running the link command. Otherwise the cocoapod will never actually be linked.

This was at least the case with my project, although interested to hear if I am wrong.
## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
