### PR TITLE
Support loading local files on WebKitWebView iOS

### DIFF
--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -398,7 +398,7 @@ static NSURLCredential* clientAuthenticationCredential;
         [_webView loadRequest:request];
     }
     else {
-        [_webView loadFileURL:request.URL allowingReadAccessToURL:request.URL];
+        [_webView loadFileURL:request.URL allowingReadAccessToURL:[request.URL URLByDeletingLastPathComponent]];
     }
 }
 


### PR DESCRIPTION
https://github.com/react-native-community/react-native-webview/issues/137#issuecomment-497304273

# Summary

Allows read access in iOS to the directory where the WebView html source file is loaded from. Previously it only allowed access to the html source file itself.
Motivation is the many scenarios where files are downloaded by the app and must be readable by WebView (think map tiles.) In Android this works out of the box, iOS however that's not the case.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |

## Checklist
- [x] I  >and others<  have tested this on a device and a simulator
- [N/A] I added the documentation in `README.md`
- [N/A] I mentioned this change in `CHANGELOG.md`
- [N/A] I updated the typed files (TS and Flow)
- [N/A] I added a sample use of the API in the example project (`example/App.js`)
