### PR TITLE
Fix `originWhitelist` escape vulnerablity

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -394,7 +394,9 @@ Note that this method will not be invoked on hash URL changes (e.g. from `https:
 
 ### `originWhitelist`
 
-List of origin strings to allow being navigated to. The strings allow wildcards and get matched against _just_ the origin (not the full URL). If the user taps to navigate to a new page but the new page is not in this whitelist, the URL will be handled by the OS. The default whitelisted origins are "http://*" and "https://*".
+List of origin strings to allow being navigated to. The strings allow wildcards and get matched against _just_ the origin (not the full URL). If the user taps to navigate to a new page but the new page is not in this whitelist, the URL will be handled by the OS. The default whitelisted origins are `"http://*"` and `"https://*"`.
+
+For example, a URL like `"https://www.example.com/a/b"` has an origin of `"https://www.example.com"`. This will match patterns like `"https://*.com"`, `"*.example.com"`, or even just `"*"`, but it will not match patterns like `"git+https://*"` or `"*.co"`.
 
 | Type             | Required |
 | ---------------- | -------- |

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -24,7 +24,7 @@ const extractOrigin = (url: string): string => {
 };
 
 const originWhitelistToRegex = (originWhitelist: string): string =>
-  `^${escapeStringRegexp(originWhitelist).replace(/\\\*/g, '.*')}`;
+  `^${escapeStringRegexp(originWhitelist).replace(/\\\*/g, '.*')}$`;
 
 const passesWhitelist = (
   compiledWhitelist: ReadonlyArray<string>,

--- a/src/__tests__/WebViewShared-test.js
+++ b/src/__tests__/WebViewShared-test.js
@@ -132,5 +132,39 @@ describe('WebViewShared', () => {
       expect(Linking.openURL).toHaveBeenLastCalledWith('FAKE+plus+https://www.example.com/');
       expect(loadRequest).toHaveBeenLastCalledWith(false, 'FAKE+plus+https://www.example.com/', 6);
     });
+
+    test('loadRequest with specific domains in whitelist', () => {
+      const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
+        loadRequest,
+        ['https://*.example.co', 'https://example.co'],
+      );
+
+      onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://www.example.co/page0', lockIdentifier: 0 } });
+      expect(Linking.openURL).toHaveBeenCalledTimes(0);
+      expect(loadRequest).toHaveBeenLastCalledWith(true, 'https://www.example.co/page0', 0);
+
+      onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://a.b.c.example.co/page1', lockIdentifier: 1 } });
+      expect(Linking.openURL).toHaveBeenCalledTimes(0);
+      expect(loadRequest).toHaveBeenLastCalledWith(true, 'https://a.b.c.example.co/page1', 1);
+
+      onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://example.co/page2', lockIdentifier: 2 } });
+      expect(Linking.openURL).toHaveBeenCalledTimes(0);
+      expect(loadRequest).toHaveBeenLastCalledWith(true, 'https://example.co/page2', 2);
+
+      // Wrong domain:
+      onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://www.example.com/page3', lockIdentifier: 3 } });
+      expect(Linking.openURL).toHaveBeenLastCalledWith('https://www.example.com/page3');
+      expect(loadRequest).toHaveBeenLastCalledWith(false, 'https://www.example.com/page3', 3);
+
+      onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://www.example.co.malicious.com', lockIdentifier: 4 } });
+      expect(Linking.openURL).toHaveBeenLastCalledWith('https://www.example.co.malicious.com');
+      expect(loadRequest).toHaveBeenLastCalledWith(false, 'https://www.example.co.malicious.com', 4);
+
+      // Wrong protocol:
+      onShouldStartLoadWithRequest({ nativeEvent: { url: 'http://www.example.co/page5', lockIdentifier: 5 } });
+      expect(Linking.openURL).toHaveBeenLastCalledWith('http://www.example.co/page5');
+      expect(loadRequest).toHaveBeenLastCalledWith(false, 'http://www.example.co/page5', 5);
+    });
+
   });
 });


### PR DESCRIPTION
# Summary

If the user specifies a specific domain for the origin whitelist, such as `https://example.co`, any domain that starts with this pattern will be valid, including `https://example.com` or `https://example.co.malicious-site.com`.

Fix this by adding a `$` to the end of the regular expression, requiring the full origin to match the provided pattern.

Note that this may be a breaking change if people are using patterns like `"https://"`, since these will no longer match. The fix is to use a wildcard, as shown in all the documentation and examples (`"https://*"`).

## Test Plan

The unit tests have been updated to exercise this vulnerability. Without the fix in place, the newly-added tests would fail.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md` (Actually `Reference.md`)
- [ ] I mentioned this change in `CHANGELOG.md` (File does not exist!!!)
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
