### PR TITLE
Added the possibility to configure the webview from the android side

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.support.annotation.RequiresApi;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -62,6 +63,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -151,7 +153,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     RNCWebView webView = createRNCWebViewInstance(reactContext);
     setupWebChromeClient(reactContext, webView);
     reactContext.addLifecycleEventListener(webView);
-    mWebViewConfig.configWebView(webView);
+
     WebSettings settings = webView.getSettings();
     settings.setBuiltInZoomControls(true);
     settings.setDisplayZoomControls(false);
@@ -212,6 +214,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       }
     });
 
+    mWebViewConfig.configWebView(webView);
     return webView;
   }
 
@@ -443,7 +446,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches
-    view.setWebViewClient(new RNCWebViewClient());
+    if(view instanceof RNCWebView){
+      if(((RNCWebView) view).getRNCWebViewClient() == null) view.setWebViewClient(new RNCWebViewClient());
+    }
+    else{
+      view.setWebViewClient(new RNCWebViewClient());
+    }
   }
 
   @Override
@@ -588,7 +596,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
   }
 
-  protected static class RNCWebViewClient extends WebViewClient {
+  public static class RNCWebViewClient extends WebViewClient {
 
     protected boolean mLastLoadFailed = false;
     protected @Nullable

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewPackage.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewPackage.java
@@ -10,6 +10,18 @@ import java.util.Collections;
 import java.util.List;
 
 public class RNCWebViewPackage implements ReactPackage {
+
+  private WebViewConfig globalNativeConfiguration;
+
+  public RNCWebViewPackage(){
+    super();
+  }
+
+  public RNCWebViewPackage(WebViewConfig globalConfigurator){
+    super();
+    this.globalNativeConfiguration = globalConfigurator;
+  }
+
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     return Collections.singletonList(new RNCWebViewModule(reactContext));
@@ -22,6 +34,7 @@ public class RNCWebViewPackage implements ReactPackage {
 
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-    return Collections.singletonList(new RNCWebViewManager());
+    RNCWebViewManager manager = globalNativeConfiguration != null ? new RNCWebViewManager(globalNativeConfiguration) : new RNCWebViewManager();
+    return Collections.singletonList(manager);
   }
 }


### PR DESCRIPTION
# Summary

I had a rather curious use case. I needed to override a bunch or URLs being loaded through a static website inside the device, mounted in a react-native-webview. In order to do that, I needed to set a bunch of listeners in the webview. Since the tutorial in the react-native-webview (https://facebook.github.io/react-native/docs/custom-webview-android) was outdated, I started reading the repo and found an interface that can be used to configure the webview component, which would allow to solve complex use cases like mine without having to create a custom react webview and therefore keeping the JS code untouched.

An issue that can be solved by this is #118 , since the user could just provide an alternative logic for the conflicting URLs. #18 can also be solved by applying this.

## Test Plan

Testing this is pretty straightforward. Just load a configuration. In the example, I'm overriding the handling of certain URIs to convert them into URLs, provide proper authorization credentials and store them into the device:

```java
RNCWebViewPackage(WebViewConfig {

                    var webViewClient = object : RNCWebViewManager.RNCWebViewClient() {
                        @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
                        override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
                            val context : Context = MainApplication.getInstance().applicationContext
                            if(ResourceCache.getInstance(context).isValidRequest(request.url.toString())){
                                if (ResourceCache.getInstance(context).isURLCached(request.url.toString(), "test")) {
                                    val file = ResourceCache.getInstance(context).getResource(request.url.toString(), "test")
                                    try {
                                        val inputStream = FileInputStream(file)
                                        val statusCode = 200
                                        val reasonPhase = "OK"
                                        val responseHeaders = HashMap<String, String>()
                                        responseHeaders["Access-Control-Allow-Origin"] = "*"
                                        return WebResourceResponse("image/jpeg", "UTF-8", statusCode, reasonPhase, responseHeaders, inputStream)
                                    } catch (e: FileNotFoundException) {
                                        e.printStackTrace()
                                    }
                                }else{
                                    return ResourceCache.getInstance(context).getWebResponse(request.url.toString(), "test")
                                }
                            }

                            return super.shouldInterceptRequest(view, request)
                        }

                        @Suppress("DEPRECATION")
                        @RequiresApi(Build.VERSION_CODES.HONEYCOMB)
                        override fun shouldInterceptRequest(view: WebView, request: String): WebResourceResponse? {
                            val context : Context = MainApplication.getInstance().applicationContext
                            if(ResourceCache.getInstance(context).isValidRequest(request)){
                                if (ResourceCache.getInstance(context).isURLCached(request, "test")) {
                                    val file = ResourceCache.getInstance(context).getResource(request, "test")
                                    try {
                                        val inputStream = FileInputStream(file)
                                        val responseHeaders = HashMap<String, String>()
                                        responseHeaders["Access-Control-Allow-Origin"] = "*"
                                        return WebResourceResponse("image/jpeg", "UTF-8", inputStream)
                                    } catch (e: FileNotFoundException) {
                                        e.printStackTrace()
                                    }

                                }else{
                                    return ResourceCache.getInstance(context).getWebResponse(request, "test")
                                }
                            }
                            return super.shouldInterceptRequest(view, request)
                        }

                        override fun shouldOverrideUrlLoading (view : WebView, request : WebResourceRequest) : Boolean {
                            return ResourceCache.getInstance(view.context).isValidRequest(request.url.toString())
                        }
                    }

                    it.settings.allowFileAccess = true
                    it.settings.allowContentAccess = true
                    it.settings.allowFileAccessFromFileURLs = true
                    it.settings.allowUniversalAccessFromFileURLs = true
                    it.settings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
                    it.webViewClient = webViewClient
                })
```

This can be test with any user case that does require a custom webview, except those who include UI changes.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS       |    ❌     |
| Android |    ✅     |

This is an android only change, neither iOs or JS should be aware of this.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
