### PR TITLE
polyfill applicationNameForUserAgent on Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -117,6 +117,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   protected RNCWebChromeClient mWebChromeClient = null;
   protected boolean mAllowsFullscreenVideo = false;
+  protected @Nullable String mUserAgent = null;
+  protected @Nullable String mUserAgentWithApplicationName = null;
 
   public RNCWebViewManager() {
     mWebViewConfig = new WebViewConfig() {
@@ -298,8 +300,34 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   @ReactProp(name = "userAgent")
   public void setUserAgent(WebView view, @Nullable String userAgent) {
     if (userAgent != null) {
-      // TODO(8496850): Fix incorrect behavior when property is unset (uA == null)
-      view.getSettings().setUserAgentString(userAgent);
+      mUserAgent = userAgent;
+    } else {
+      mUserAgent = null;
+    }
+    this.setUserAgentString(view);
+  }
+
+  @ReactProp(name = "applicationNameForUserAgent")
+  public void setApplicationNameForUserAgent(WebView view, @Nullable String applicationName) {
+    if(applicationName != null) {
+      if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+        String defaultUserAgent = WebSettings.getDefaultUserAgent(view.getContext());
+        mUserAgentWithApplicationName = defaultUserAgent + " " + applicationName;
+      }
+    } else {
+      mUserAgentWithApplicationName = null;
+    }
+    this.setUserAgentString(view);
+  }
+
+  protected void setUserAgentString(WebView view) {
+    if(mUserAgent != null) {
+      view.getSettings().setUserAgentString(mUserAgent);
+    } else if(mUserAgentWithApplicationName != null) {
+      view.getSettings().setUserAgentString(mUserAgentWithApplicationName);
+    } else if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      // handle unsets of `userAgent` prop as long as device is >= API 17
+      view.getSettings().setUserAgentString(WebSettings.getDefaultUserAgent(view.getContext()));
     }
   }
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -613,11 +613,21 @@ Sets the user-agent for the `WebView`. This will only work for iOS if you are us
 
 ### `applicationNameForUserAgent`
 
-Append to the existing user-agent. Available on iOS WKWebView only. Setting `userAgent` will override this.
+Append to the existing user-agent. This will only work for iOS if you are using WKWebView, not UIWebView. Setting `userAgent` will override this.
 
 | Type   | Required | Platform      |
 | ------ | -------- | ------------- |
-| string | No       | iOS WKWebView |
+| string | No       | Android, iOS WKWebView |
+
+```jsx
+<WebView
+  source={{ uri: 'https://facebook.github.io/react-native' }}
+  applicationNameForUserAgent={"DemoApp/1.1.0"}
+/>
+// Resulting User-Agent will look like:
+// Mozilla/5.0 (Linux; Android 8.1.0; Android SDK built for x86 Build/OSM1.180201.021; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36 DemoApp/1.1.0
+// Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 DemoApp/1.1.0
+```
 
 ### `allowsFullscreenVideo`
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -229,6 +229,10 @@ export interface CommonNativeWebViewProps extends ViewProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   source: any;
   userAgent?: string;
+  /**
+   * Append to the existing user-agent. Overriden if `userAgent` is set.
+   */
+  applicationNameForUserAgent?: string;
 }
 
 export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
@@ -377,12 +381,6 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   useSharedProcessPool?: boolean;
-
-  /**
-   * Append to the existing user-agent. Overriden if `userAgent` is set.
-   * @platform ios
-   */
-  applicationNameForUserAgent?: string;
 
   /**
    * The custom user agent string.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This will make the `applicationNameForUserAgent` cross platform.
This prop was originally added in https://github.com/react-native-community/react-native-webview/pull/506

Note: There was a TODO in the area I was working about handling unsetting of the `userAgent` prop so I did that too.

## Test Plan
| iOS      | Android |
| ------- | ------- |
| ![Screen Shot 2019-07-08 at 5 52 37 PM](https://user-images.githubusercontent.com/333260/60845094-3c9d5680-a1a9-11e9-94ba-e05f35ca8044.png) | ![Screen Shot 2019-07-08 at 5 54 59 PM](https://user-images.githubusercontent.com/333260/60845183-89812d00-a1a9-11e9-9147-9fe2d1a22a58.png) |

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?
```
<WebView
  source={{ uri: `https://www.whatsmyua.info/` }}
  applicationNameForUserAgent={"DemoApp/1.1.0"}
/>
```
See that on both iOS and Android the Application name is now appended to the UserAgent with a space.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `Reference.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
