### PR TITLE
Adding a `contentInsetAdjustmentBehavior` prop to the WebView for iOS.

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -36,6 +36,7 @@ This document lays out the current public properties and methods for the React N
 - [`bounces`](Reference.md#bounces)
 - [`overScrollMode`](Reference.md#overscrollmode)
 - [`contentInset`](Reference.md#contentinset)
+- [`contentInsetAdjustmentBehavior`](Reference.md#contentInsetAdjustmentBehavior)
 - [`dataDetectorTypes`](Reference.md#datadetectortypes)
 - [`scrollEnabled`](Reference.md#scrollenabled)
 - [`directionalLockEnabled`](Reference.md#directionalLockEnabled)
@@ -676,6 +677,23 @@ The amount by which the web view content is inset from the edges of the scroll v
 | Type                                                               | Required | Platform |
 | ------------------------------------------------------------------ | -------- | -------- |
 | object: {top: number, left: number, bottom: number, right: number} | No       | iOS      |
+
+---
+
+### `contentInsetAdjustmentBehavior`
+
+This property specifies how the safe area insets are used to modify the content area of the scroll view. The default value of this property is "never". Available on iOS 11 and later. Defaults to `never`.
+
+Possible values:
+
+- `automatic`
+- `scrollableAxes`
+- `never`
+- `always`
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | iOS      |
 
 ---
 

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -49,6 +49,10 @@ static NSURLCredential* clientAuthenticationCredential;
   BOOL _isFullScreenVideoOpen;
   UIStatusBarStyle _savedStatusBarStyle;
   BOOL _savedStatusBarHidden;
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
+  UIScrollViewContentInsetAdjustmentBehavior _savedContentInsetAdjustmentBehavior;
+#endif
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -65,6 +69,10 @@ static NSURLCredential* clientAuthenticationCredential;
     _savedKeyboardDisplayRequiresUserAction = YES;
     _savedStatusBarStyle = RCTSharedApplication().statusBarStyle;
     _savedStatusBarHidden = RCTSharedApplication().statusBarHidden;
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
+    _savedContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+#endif
   }
 
   if (@available(iOS 12.0, *)) {
@@ -227,7 +235,7 @@ static NSURLCredential* clientAuthenticationCredential;
     }
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
     if ([_webView.scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
-      _webView.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+      _webView.scrollView.contentInsetAdjustmentBehavior = _savedContentInsetAdjustmentBehavior;
     }
 #endif
 
@@ -327,6 +335,22 @@ static NSURLCredential* clientAuthenticationCredential;
   _webView.scrollView.backgroundColor = backgroundColor;
   _webView.backgroundColor = backgroundColor;
 }
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
+- (void)setContentInsetAdjustmentBehavior:(UIScrollViewContentInsetAdjustmentBehavior)behavior
+{
+    _savedContentInsetAdjustmentBehavior = behavior;
+    if (_webView == nil) {
+        return;
+    }
+
+    if ([_webView.scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
+        CGPoint contentOffset = _webView.scrollView.contentOffset;
+        _webView.scrollView.contentInsetAdjustmentBehavior = behavior;
+        _webView.scrollView.contentOffset = contentOffset;
+    }
+}
+#endif
 
 /**
  * This method is called whenever JavaScript running within the web view calls:

--- a/ios/RNCWKWebViewManager.m
+++ b/ios/RNCWKWebViewManager.m
@@ -14,6 +14,19 @@
 @interface RNCWKWebViewManager () <RNCWKWebViewDelegate>
 @end
 
+@implementation RCTConvert (UIScrollView)
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
+RCT_ENUM_CONVERTER(UIScrollViewContentInsetAdjustmentBehavior, (@{
+                                                                  @"automatic": @(UIScrollViewContentInsetAdjustmentAutomatic),
+                                                                  @"scrollableAxes": @(UIScrollViewContentInsetAdjustmentScrollableAxes),
+                                                                  @"never": @(UIScrollViewContentInsetAdjustmentNever),
+                                                                  @"always": @(UIScrollViewContentInsetAdjustmentAlways),
+                                                                  }), UIScrollViewContentInsetAdjustmentNever, integerValue)
+#endif
+
+@end
+
 @implementation RNCWKWebViewManager
 {
   NSConditionLock *_shouldStartLoadLock;
@@ -51,6 +64,10 @@ RCT_EXPORT_VIEW_PROPERTY(userAgent, NSString)
 RCT_EXPORT_VIEW_PROPERTY(applicationNameForUserAgent, NSString)
 RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
+RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)
+#endif
 
 /**
  * Expose methods to enable messaging the webview.

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -381,7 +381,6 @@ class WebView extends React.Component<IOSWebViewProps, State> {
         scalesPageToFit={scalesPageToFit}
         // TODO: find a better way to type this.
         source={resolveAssetSource(this.props.source as ImageSourcePropType)}
-        contentInsetAdjustmentBehavior={this.props.contentInsetAdjustmentBehavior}
         style={webViewStyles}
         {...nativeConfig.props}
       />

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -381,6 +381,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
         scalesPageToFit={scalesPageToFit}
         // TODO: find a better way to type this.
         source={resolveAssetSource(this.props.source as ImageSourcePropType)}
+        contentInsetAdjustmentBehavior={this.props.contentInsetAdjustmentBehavior}
         style={webViewStyles}
         {...nativeConfig.props}
       />

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -254,6 +254,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   automaticallyAdjustContentInsets?: boolean;
   bounces?: boolean;
   contentInset?: ContentInsetProp;
+  contentInsetAdjustmentBehavior?: 'automatic'| 'scrollableAxes' | 'never' | 'always';
   dataDetectorTypes?: DataDetectorTypes | ReadonlyArray<DataDetectorTypes>;
   decelerationRate?: number;
   directionalLockEnabled?: boolean;
@@ -318,6 +319,13 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   automaticallyAdjustContentInsets?: boolean;
+
+  /**
+   * This property specifies how the safe area insets are used to modify the
+   * content area of the scroll view. The default value of this property is
+   * "never". Available on iOS 11 and later.
+   */
+  contentInsetAdjustmentBehavior?: 'automatic'| 'scrollableAxes' | 'never' | 'always'
 
   /**
    * The amount by which the web view content is inset from the edges of


### PR DESCRIPTION
This controls the way iOS will automatically adjust the insets when the
webview is behind things like the iPhone X notch.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

### Problem:
On devices like the iPhone X, the WebView will put part of the content under the notch, by default.

### Solution:
Add a new prop `contentInsetAdjustmentBehavior` (just for iOS) that lets users tell the webview to adjust content automatically.

### How:
This is a copy (more or less) of the implementation that exists in react-native-wkwebview-reborn.


## Test Plan

### Before:

Running on iOS w/o the change:
<img width="400" alt="before" src="https://user-images.githubusercontent.com/3768353/61494889-4e7eb680-a96c-11e9-8af4-47b180ef47e4.png">

### After:

Running on iOS w/ the change (and passing "always" to `contentInsetAdjustmentBehavior`):

<img width="400" alt="after" src="https://user-images.githubusercontent.com/3768353/61494902-58081e80-a96c-11e9-9b50-12a26cb1df70.png">

### Android

Also I ran the code on Android JIC (setting the prop) and everything was fine.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

No prereqs.

### What are the steps to reproduce (after prerequisites)?

Running an app w/ the WebView (taking up a large amount of screen space) on an iPhone X, rotate the device, notice the webview content appearing under the notch.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌(n/a)     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in ~~`README.md`~~ `Reference.md`
- [ ] I mentioned this change in `CHANGELOG.md`  (Aaron: not sure its a big enough change to callout?)
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)  (Aaron: not sure its necessary?)




Let me know if I missed anything in this change, or you'd like something to be done differently.  I'd be happy to make any changes.

