### PR TITLE
Fixes #502. Error evaluating injectedJavaScript should be warning instead of redbox error

### DIFF
--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -795,12 +795,11 @@ static NSURLCredential* clientAuthenticationCredential;
           thenCall: (void (^)(NSString*)) callback
 {
   [self.webView evaluateJavaScript: js completionHandler: ^(id result, NSError *error) {
-    if (error == nil) {
-      if (callback != nil) {
-        callback([NSString stringWithFormat:@"%@", result]);
-      }
-    } else {
-      RCTLogError(@"Error evaluating injectedJavaScript: This is possibly due to an unsupported return type. Try adding true to the end of your injectedJavaScript string.");
+    if (callback != nil) {
+      callback([NSString stringWithFormat:@"%@", result]);
+    }
+    if (error != nil) {
+      RCTLogWarn([NSString stringWithFormat:@"Error evaluating injectedJavaScript: This is possibly due to an unsupported return type. Try adding true to the end of your injectedJavaScript string. %@", error]);
     }
   }];
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged #502 
* Changes error/redbox into warning/yellowbox on evaluating bad injected JS. So wouldn't crash production releases
* Warning added actual error, useful for debugging bad JS injected into webview
* callback runs, whether there's error or not. As used in my app (https://medium.com/wonderswipe/rethink-mobile-search-10-100x-faster-introducing-wonderswipe-6f2ff0d0e667) which injects JS into sanitized html from the wild, small error in injected JS doesn't warrant the whole JS payload from being injected/run

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)

## PS.

On Android, error evaluating injectedJavaScript currently fail silently. A separate PR to implement an equivalent of warning to console, with actual JS `error` would be useful.