### PR TITLE
Fix signature of the swizzled `elementDidFocus` method on iOS 13

### DIFF
--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -426,12 +426,22 @@ static NSURLCredential* clientAuthenticationCredential;
   
     NSOperatingSystemVersion iOS_11_3_0 = (NSOperatingSystemVersion){11, 3, 0};
     NSOperatingSystemVersion iOS_12_2_0 = (NSOperatingSystemVersion){12, 2, 0};
+    NSOperatingSystemVersion iOS_13_0_0 = (NSOperatingSystemVersion){13, 0, 0};
 
     Method method;
     IMP override;
-  
-    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_12_2_0]) {
-        // iOS 12.2.0 - Future
+
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_13_0_0]) {
+        // iOS 13.0.0 - Future
+        SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:");
+        method = class_getInstanceMethod(class, selector);
+        IMP original = method_getImplementation(method);
+        override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+            ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
+        });
+    }
+    else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_12_2_0]) {
+        // iOS 12.2.0 - iOS 13.0.0
         SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
         method = class_getInstanceMethod(class, selector);
         IMP original = method_getImplementation(method);


### PR DESCRIPTION
# Summary

iOS 13 has included [webkit change](https://github.com/WebKit/webkit/commit/3d92cb040253760233028c6c13c9e940744f5265) that has renamed the signature of `_elementDidFocus` method

## Test Plan
Retesting https://github.com/react-native-community/react-native-webview/pull/540 usign iOS 13
## Compatibility
| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
