### PR TITLE
Add prop for allowingReadAccessToURL on iOS WKWebView

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -41,6 +41,7 @@ This document lays out the current public properties and methods for the React N
 - [`directionalLockEnabled`](Reference.md#directionalLockEnabled)
 - [`geolocationEnabled`](Reference.md#geolocationenabled)
 - [`allowUniversalAccessFromFileURLs`](Reference.md#allowUniversalAccessFromFileURLs)
+- [`allowingReadAccessToURL`](Reference.md#allowingReadAccessToURL)
 - [`useWebKit`](Reference.md#usewebkit)
 - [`url`](Reference.md#url)
 - [`html`](Reference.md#html)
@@ -774,6 +775,16 @@ Boolean that sets whether JavaScript running in the context of a file scheme URL
 | Type | Required | Platform |
 | ---- | -------- | -------- |
 | bool | No       | Android  |
+
+---
+
+### `allowingReadAccessToURL`
+
+A String value that indicates which URLs the WebView's file can then reference in scripts, AJAX requests, and CSS imports. This is only used in `RNCWKWebView` for WebViews that are loaded with a source.uri set to a `'file://'` URL. If not provided, the default is to only allow read access to the URL provided in source.uri itself.
+
+| Type   | Required | Platform      |
+| ------ | -------- | ------------- |
+| string | No       | iOS WKWebView |
 
 ---
 

--- a/ios/RNCWKWebView.h
+++ b/ios/RNCWKWebView.h
@@ -49,6 +49,7 @@
 @property (nonatomic, assign) BOOL showsHorizontalScrollIndicator;
 @property (nonatomic, assign) BOOL showsVerticalScrollIndicator;
 @property (nonatomic, assign) BOOL directionalLockEnabled;
+@property (nonatomic, copy) NSString *allowingReadAccessToURL;
 
 + (void)setClientAuthenticationCredential:(nullable NSURLCredential*)credential;
 - (void)postMessage:(NSString *)message;

--- a/ios/RNCWKWebView.m
+++ b/ios/RNCWKWebView.m
@@ -353,6 +353,17 @@ static NSURLCredential* clientAuthenticationCredential;
   }
 }
 
+- (void)setAllowingReadAccessToURL:(NSString *)allowingReadAccessToURL
+{
+  if (![_allowingReadAccessToURL isEqualToString:allowingReadAccessToURL]) {
+    _allowingReadAccessToURL = [allowingReadAccessToURL copy];
+
+    if (_webView != nil) {
+      [self visitSource];
+    }
+  }
+}
+
 - (void)setContentInset:(UIEdgeInsets)contentInset
 {
   _contentInset = contentInset;
@@ -398,7 +409,8 @@ static NSURLCredential* clientAuthenticationCredential;
         [_webView loadRequest:request];
     }
     else {
-        [_webView loadFileURL:request.URL allowingReadAccessToURL:request.URL];
+        NSURL* readAccessUrl = _allowingReadAccessToURL ? [NSURL URLWithString:_allowingReadAccessToURL] : request.URL;
+        [_webView loadFileURL:request.URL allowingReadAccessToURL:readAccessUrl];
     }
 }
 

--- a/ios/RNCWKWebViewManager.m
+++ b/ios/RNCWKWebViewManager.m
@@ -51,6 +51,7 @@ RCT_EXPORT_VIEW_PROPERTY(userAgent, NSString)
 RCT_EXPORT_VIEW_PROPERTY(applicationNameForUserAgent, NSString)
 RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
 
 /**
  * Expose methods to enable messaging the webview.

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -254,6 +254,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
 }
 
 export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
+  allowingReadAccessToURL?: string;
   allowsBackForwardNavigationGestures?: boolean;
   allowsInlineMediaPlayback?: boolean;
   allowsLinkPreview?: boolean;
@@ -424,6 +425,18 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   keyboardDisplayRequiresUserAction?: boolean;
+
+  /**
+   * A String value that indicates which URLs the WebView's file can then
+   * reference in scripts, AJAX requests, and CSS imports. This is only used
+   * in `RNCWKWebView` for WebViews that are loaded with a source.uri set to a
+   * `'file://'` URL.
+   * 
+   * If not provided, the default is to only allow read access to the URL
+   * provided in source.uri itself.
+   * @platform ios
+   */
+  allowingReadAccessToURL?: string;
 }
 
 export interface AndroidWebViewProps extends WebViewSharedProps {


### PR DESCRIPTION
# Summary

By default, the WKWebView sets `allowingReadAccessToURL` to just the file itself when provided with `source={{ uri: 'file://myFile' }}`. This means that it's not possible to access any other CSS or JS on the filesystem from within the WebView.

This change adds a prop that lets users customize `allowingReadAccessToURL`. The default is still to only allow access to just the file itself, but users can now override it.

**Important: allowingReadAccessToURL is ignored on the emulator. This must be tested on your device**

## Test Plan

See https://github.com/hsource/test-allowing-read-access/tree/master

To test that it works:

1. Clone the test repository `git clone https://github.com/hsource/test-allowing-read-access.git`
2. Go into the directory and run `yarn install` and `cd ios; pod install; cd ..`
3. Go into Xcode and make sure the project is signed with a development team so it can be loaded onto device
4. Run on a real iOS device by running `react-native run-ios --device`

You should see that in the first WebView, the JS doesn't replace the first line and the second line isn't red, while in the second WebView, the first line is replaced by the JS and the second line is red.

You can check that both WebViews don't execute JS or apply styles in previous versions of React Native WebView by doing:
1. `yarn add react-native-webview` - this installs the last published version of WebView
2. `cd ios; pod install; cd ..`
3. `react-native run-ios --device`

Now both WebViews should have black text that's not replaced by JS.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌ (not needed)     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
