### PR TITLE
Allow user to rotate fullscreen video on Android (No Android X)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -5,6 +5,7 @@ import android.annotation.TargetApi;
 import android.app.DownloadManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.Uri;
@@ -533,6 +534,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   protected void setupWebChromeClient(ReactContext reactContext, WebView webView) {
     if (mAllowsFullscreenVideo) {
+      int initialRequestedOrientation = reactContext.getCurrentActivity().getRequestedOrientation();
       mWebChromeClient = new RNCWebChromeClient(reactContext, webView) {
         @Override
         public void onShowCustomView(View view, CustomViewCallback callback) {
@@ -544,6 +546,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           mVideoView = view;
           mCustomViewCallback = callback;
 
+          mReactContext.getCurrentActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             mVideoView.setSystemUiVisibility(FULLSCREEN_SYSTEM_UI_VISIBILITY);
             mReactContext.getCurrentActivity().getWindow().setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
@@ -574,6 +577,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             mReactContext.getCurrentActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
           }
+          mReactContext.getCurrentActivity().setRequestedOrientation(initialRequestedOrientation);
 
           mReactContext.removeLifecycleEventListener(this);
         }


### PR DESCRIPTION
# Summary

This change updates the fullscreen video support in Android to match the behavior in iOS so that the user can rotate the screen regardless of the default orientation defined in the app. For example, if `android:screenOrientation="portrait"` is defined within the manifest, then the video will always displayed in portrait mode regardless of the aspect ratio in the video. Related to https://github.com/react-native-community/react-native-webview/issues/586. Also see Android X version of this PR at https://github.com/react-native-community/react-native-webview/pull/816  

This change also avoids some of the pitfalls of forcing screen orientation discussed in https://github.com/react-native-community/react-native-webview/pull/325#pullrequestreview-203973316 
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What are the steps to reproduce (after prerequisites)?
- Set `android:screenOrientation="portrait"` in AndroidManifest.xml
- Open a webview with an embedded landscape video containing a full screen button
- Rotate the screen between landscape / portrait mode

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |