### PR TITLE
Update README to improve first encounter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ import { WebView } from 'react-native-webview';
 class MyWebComponent extends Component {
   render() {
     return (
-      <WebView source={{ uri: 'https://facebook.github.io/react-native/' }} />
+      <WebView source={{ uri: 'https://facebook.github.io/react-native/' }} scalesPageToFit={true} />
     );
   }
 }


### PR DESCRIPTION
I had problems when I tried `react-native-webview` for the first time in a freshly created react native 0.60 project. It just showed a blank page because width and height were zero. Scaling the page should at least show something and improve the initial experience with this library.