### PR TITLE
fix(android): Move noisy debug logging out of "quiet" log level.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,7 +72,7 @@ repositories {
       name androidSourcesName
     }
 
-    logger.quiet(":${project.name}:reactNativeAndroidRoot ${defaultDir.canonicalPath}")
+    logger.info(":${project.name}:reactNativeAndroidRoot ${defaultDir.canonicalPath}")
     found = true
   } else {
     def parentDir = rootProject.projectDir
@@ -97,7 +97,7 @@ repositories {
           name androidSourcesName
         }
 
-        logger.quiet(":${project.name}:reactNativeAndroidRoot ${androidPrebuiltBinaryDir.canonicalPath}")
+        logger.info(":${project.name}:reactNativeAndroidRoot ${androidPrebuiltBinaryDir.canonicalPath}")
         found = true
       } else if (androidSourcesDir.exists()) {
         maven {
@@ -105,7 +105,7 @@ repositories {
           name androidSourcesName
         }
 
-        logger.quiet(":${project.name}:reactNativeAndroidRoot ${androidSourcesDir.canonicalPath}")
+        logger.info(":${project.name}:reactNativeAndroidRoot ${androidSourcesDir.canonicalPath}")
         found = true
       }
     })


### PR DESCRIPTION
# Summary

Each time building our app, this library causes a message like this
one to be printed, sometimes twice:

  > Configure project :react-native-webview
  :react-native-webview:reactNativeAndroidRoot /home/greg/z/mobile/node_modules/react-native/android

Worse, the message comes through even if I silence all normal
progress messages and warnings, with `./gradlew --quiet`.

It turns out that the `logger.quiet` method which these log lines are
using has a confusing name.  It doesn't mean "log quietly", but more
like the opposite: "log even when asked to keep things quiet".  See
documentation on Gradle log levels:
  https://docs.gradle.org/current/userguide/logging.html

So, remove the noise by switching to `logger.info`.  This avoids
bothering the user by default, and keeps the information readily
available if desired by passing `--info` to Gradle.

## Test Plan

In our app, after this change, a normal `./gradlew assembleDebug` runs
just like before but without this log message.

When the log message is desired, this works to get it:

  $ ./gradlew assembleDebug --info | grep reactNativeAndroidRoot
  :react-native-webview:reactNativeAndroidRoot /home/greg/z/mobile/node_modules/react-native/android

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    n/a     |
| Android |    ✅     |

## Checklist

- n/a I have tested this on a device and a simulator
- n/a I added the documentation in `README.md`
- n/a I mentioned this change in `CHANGELOG.md`
- n/a I updated the typed files (TS and Flow)
- n/a I added a sample use of the API in the example project (`example/App.js`)
