### PR TITLE
Fix(iOS):use RCTConvert to convert allowingReadAccessToURL.

### DIFF
--- a/ios/RNCWebView.m
+++ b/ios/RNCWebView.m
@@ -438,7 +438,11 @@ static NSURLCredential* clientAuthenticationCredential;
         [_webView loadRequest:request];
     }
     else {
-        NSURL* readAccessUrl = _allowingReadAccessToURL ? [NSURL URLWithString:_allowingReadAccessToURL] : request.URL;
+        NSURL* readAccessUrl = request.URL;
+        if(_allowingReadAccessToURL){
+            NSString *accessUrl = [_allowingReadAccessToURL stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+            readAccessUrl = [RCTConvert NSURL:accessUrl];
+        }
         [_webView loadFileURL:request.URL allowingReadAccessToURL:readAccessUrl];
     }
 }

--- a/ios/RNCWebView.m
+++ b/ios/RNCWebView.m
@@ -438,11 +438,7 @@ static NSURLCredential* clientAuthenticationCredential;
         [_webView loadRequest:request];
     }
     else {
-        NSURL* readAccessUrl = request.URL;
-        if(_allowingReadAccessToURL){
-            NSString *accessUrl = [_allowingReadAccessToURL stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-            readAccessUrl = [RCTConvert NSURL:accessUrl];
-        }
+        NSURL* readAccessUrl = _allowingReadAccessToURL ? [RCTConvert NSURL:_allowingReadAccessToURL] : request.URL;
         [_webView loadFileURL:request.URL allowingReadAccessToURL:readAccessUrl];
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
It's not safe to convert NSString to NSURL by URLWithString directly.
If NSString is not a valid URL (maybe contains some special characters), it will return nil.
This PR change URLWithString into RCTConvert.
Not only fix the above issue but prop allowingReadAccessToURL also don't need the file:// prefix.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
[Test repository](https://github.com/hank121314/iOS_WKWebview_Test)(reference to: https://github.com/hsource/test-allowing-read-access/tree/master)

1.Clone the test repository and
`yarn && cd ios && pod install`
2.Run on a real device.

## Result
![image](https://github.com/hank121314/iOS_WKWebview_Test/blob/master/result/IMG_0188.png?raw=true)


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
