### PR TITLE
chore(docs): add documentation meta data

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "prepare": "yarn build",
     "test": "yarn jest"
   },
+  "rn-docs": {
+    "title": "Webview",
+    "type": "Component"
+  },
   "peerDependencies": {
     "react": "^16.0",
     "react-native": ">=0.60 <0.62"


### PR DESCRIPTION
This adds the metadata used by react-native-website to include the Webview component back in the API documentation.