### PR TITLE
Upgrade react-native types

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/invariant": "^2.2.29",
     "@types/jest": "24.0.11",
     "@types/react": "16.8.8",
-    "@types/react-native": "0.57.40",
+    "@types/react-native": "0.60.11",
     "@typescript-eslint/eslint-plugin": "1.4.2",
     "@typescript-eslint/parser": "1.4.2",
     "babel-eslint": "10.0.1",

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -73,7 +73,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().goForward,
-      null,
+      undefined,
     );
   };
 
@@ -81,7 +81,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().goBack,
-      null,
+      undefined,
     );
   };
 
@@ -92,7 +92,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().reload,
-      null,
+      undefined,
     );
   };
 
@@ -100,7 +100,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().stopLoading,
-      null,
+      undefined,
     );
   };
 
@@ -108,7 +108,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().requestFocus,
-      null,
+      undefined,
     );
   };
 

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -82,7 +82,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().goForward,
-      null,
+      undefined,
     );
   };
 
@@ -93,7 +93,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().goBack,
-      null,
+      undefined,
     );
   };
 
@@ -105,7 +105,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().reload,
-      null,
+      undefined,
     );
   };
 
@@ -116,7 +116,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().stopLoading,
-      null,
+      undefined,
     );
   };
 
@@ -127,7 +127,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().requestFocus,
-      null,
+      undefined,
     );
   };
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -11,28 +11,20 @@ import {
 } from 'react-native';
 
 export interface WebViewCommands {
-  goForward: Function;
-  goBack: Function;
-  reload: Function;
-  stopLoading: Function;
-  postMessage: Function;
-  injectJavaScript: Function;
-  loadUrl: Function;
-  requestFocus: Function;
+  goForward: number;
+  goBack: number;
+  reload: number;
+  stopLoading: number;
+  postMessage: number;
+  injectJavaScript: number;
+  loadUrl: number;
+  requestFocus: number;
 }
 
 export interface CustomUIManager extends UIManagerStatic {
   getViewManagerConfig: (
     name: string,
   ) => {
-    Commands: WebViewCommands;
-  };
-  dispatchViewManagerCommand: (
-    viewHandle: number,
-    command: Function,
-    params: object | null,
-  ) => void;
-  RNCWebView: {
     Commands: WebViewCommands;
   };
 }


### PR DESCRIPTION
Currently using `react-native-webview` with newer versions of `@types/react-native` results in a type error, preventing projects from being built. Specifically, given:

```
"@types/react-native": "0.60.11",
"react-native-webview": "7.0.3",
```

you will get

```
node_modules/react-native-webview/lib/WebViewTypes.d.ts:13:18 - error TS2430: Interface 'CustomUIManager' incorrectly extends interface 'UIManagerStatic'.
  Types of property 'dispatchViewManagerCommand' are incompatible.
    Type '(viewHandle: number, command: Function, params: object | null) => void' is not assignable to type '(reactTag: number | null, commandID: number, commandArgs?: any[] | undefined) => void'.
      Types of parameters 'viewHandle' and 'reactTag' are incompatible.
        Type 'number | null' is not assignable to type 'number'.
          Type 'null' is not assignable to type 'number'.

13 export interface CustomUIManager extends UIManagerStatic {
                    ~~~~~~~~~~~~~~~
```

This stems from a combination of issues: 
1. Historically the react-native `UIManager` hasn't been typed well, which is why `react-native-webview` does [this overriding](https://github.com/react-native-community/react-native-webview/blob/master/src/WebView.ios.tsx#L34).
2. `react-native-webview` incorrectly defined the types of `UIManager` in the `CustomUIManager` type. 
3. Improvements to `@types/react-native` have started to add (correct) types for `UIManager`, which now conflict with overriding that `react-native-webview` does. 

Specifically `react-native-webview` types the `command` argument of `dispatchViewManagerCommand` as a `Function` which is incorrect, since `dispatchViewManagerCommand` is calling a native function, the command is an ID, not a JS function, and as such the correct type is `Number` (similar to the `viewHandle` argument, which is _correctly_ typed as a `number` already). 

This PR upgrades the react-native types to match the react-native version (these should generally be in minor version lockstep as I understand it), and then removes the unneeded (and incorrect) type overrides of `dispatchViewManagerCommand`. It also fixes the typing of `WebViewCommands` and switches some `null`s to `undefined`s so as to conform to the `react-native` types.

## Test Plan
Given the versions listed above `node_modules/.bin/tsc -p .` no longer fails, meaning we now correctly comply with the types. 

A core tenet of typescript is changing types cannot change the output of code, so changing the types should be a safe change from a functionality perspective. 

The only change that could impact functionality is switching the `null`s to `undefined`s to comply with the types, but given the nature of this change, and given that `react-native-webview` had the incorrect types, this change seems safe. 


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)

Please let me know if there's anything additional you need from me and what the process to get this merged/deployed will be. 