### PR TITLE
fix(types): Export WebViewMessageEvent, WebViewNavigation for external use

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,8 @@ import { Component } from 'react';
 // eslint-disable-next-line
 import { IOSWebViewProps, AndroidWebViewProps } from './lib/WebViewTypes';
 
+export { WebViewMessageEvent, WebViewNavigation } from "./lib/WebViewTypes";
+
 export type WebViewProps = IOSWebViewProps & AndroidWebViewProps;
 
 declare class WebView extends Component<WebViewProps> {


### PR DESCRIPTION
# Summary

This change simply exports `WebViewMessageEvent` and `WebViewNavigation` so consumers can type check their callbacks.

## Test Plan

Everything should build successfully as usual.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
