### PR TITLE
Call dispatchViewManagerCommand with correct number of arguments

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -73,6 +73,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().goForward,
+      undefined
     );
   };
 
@@ -80,6 +81,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().goBack,
+      undefined
     );
   };
 
@@ -90,6 +92,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().reload,
+      undefined
     );
   };
 
@@ -97,6 +100,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().stopLoading,
+      undefined
     );
   };
 
@@ -104,6 +108,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().requestFocus,
+      undefined
     );
   };
 

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -82,6 +82,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().goForward,
+      undefined,
     );
   };
 
@@ -92,6 +93,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().goBack,
+      undefined,
     );
   };
 
@@ -103,6 +105,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().reload,
+      undefined,
     );
   };
 
@@ -113,6 +116,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().stopLoading,
+      undefined,
     );
   };
 
@@ -123,6 +127,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewHandle(),
       this.getCommands().requestFocus,
+      undefined,
     );
   };
 


### PR DESCRIPTION
# Summary
In https://github.com/react-native-community/react-native-webview/pull/847 we changed how we were calling `dispatchViewManagerCommand`, instead of passing `null` as the final argument (`commandArgs`) we switched to just leaving the argument off. The react-native types specify this as an optional param, but really that type should be `any[] | undefined`. As such this seemed like a safe change to make, when in fact it was not because react native is strict about argument counts, meaning that **anyone who upgrades to 7.07 gets a crash when using any of `goBack`/`goForward` etc methods**. Because this is a patch release it's very possible that people will accidentally upgrade to this version. 

This PR switches to using `undefined` which both matches the RN types and satisfies the argument count strictness.


## Test Plan
I tested this change in our application by editing the code in `node_modules` and verifying the error was resolved. It seems like we should probably figure out a more sustainable test plan for this, because it's a pretty huge foot gun currently. However due to the impact of this issue, and the fact it's currently live on a patch version bump, I'm not sure it should block the fix. At the very least we should probably unpublish `7.0.7`? Would love other's feedback here. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)