### PR TITLE
fix(types): Make onContentProcessDidTerminate optional

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -271,7 +271,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   pagingEnabled?: boolean;
   scrollEnabled?: boolean;
   useSharedProcessPool?: boolean;
-  onContentProcessDidTerminate: (event: WebViewTerminatedEvent) => void;
+  onContentProcessDidTerminate?: (event: WebViewTerminatedEvent) => void;
 }
 
 export interface IOSWebViewProps extends WebViewSharedProps {
@@ -450,7 +450,7 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * Function that is invoked when the WebKit WebView content process gets terminated.
    * @platform ios
    */
-  onContentProcessDidTerminate: (event: WebViewTerminatedEvent) => void;
+  onContentProcessDidTerminate?: (event: WebViewTerminatedEvent) => void;
 }
 
 export interface AndroidWebViewProps extends WebViewSharedProps {


### PR DESCRIPTION
## Summary

Based on the documentation, `onContentProcessDidTerminate` should be optional but it isn't in typing.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

It should build successfully.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |   ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
