### PR TITLE
fix(iOS): Fix changing notification bars #735

### DIFF
--- a/ios/RNCWebView.m
+++ b/ios/RNCWebView.m
@@ -92,7 +92,15 @@ static NSDictionary* customCertificatesForHost;
 
     // Workaround for StatusBar appearance bug for iOS 12
     // https://github.com/react-native-community/react-native-webview/issues/62
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(toggleFullScreenVideoStatusBars) name:@"_MRMediaRemotePlayerSupportedCommandsDidChangeNotification" object:nil];
+      [[NSNotificationCenter defaultCenter] addObserver:self
+                                               selector:@selector(showFullScreenVideoStatusBars)
+                                                   name:UIWindowDidBecomeVisibleNotification
+                                                 object:nil];
+
+      [[NSNotificationCenter defaultCenter] addObserver:self
+                                               selector:@selector(hideFullScreenVideoStatusBars)
+                                                   name:UIWindowDidBecomeHiddenNotification
+                                                 object:nil];
   }
 
   return self;
@@ -275,21 +283,24 @@ static NSDictionary* customCertificatesForHost;
     [super removeFromSuperview];
 }
 
--(void)toggleFullScreenVideoStatusBars
+-(void)showFullScreenVideoStatusBars
 {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if (!_isFullScreenVideoOpen) {
     _isFullScreenVideoOpen = YES;
     RCTUnsafeExecuteOnMainQueueSync(^{
       [RCTSharedApplication() setStatusBarStyle:UIStatusBarStyleLightContent animated:YES];
     });
-  } else {
+#pragma clang diagnostic pop
+}
+
+-(void)hideFullScreenVideoStatusBars
+{
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     _isFullScreenVideoOpen = NO;
     RCTUnsafeExecuteOnMainQueueSync(^{
       [RCTSharedApplication() setStatusBarHidden:self->_savedStatusBarHidden animated:YES];
       [RCTSharedApplication() setStatusBarStyle:self->_savedStatusBarStyle animated:YES];
     });
-  }
 #pragma clang diagnostic pop
 }
 


### PR DESCRIPTION
UIWindowDidBecomeVisibleNotification and UIWindowDidBecomeHiddenNotification seem to be far more reliable events to detect when the video enters or leaves fullscreen

# Summary

This should fix the following bug: https://github.com/react-native-community/react-native-webview/issues/735

## Tests

I tested the code on iOS 12 and 13. No other tests have been done so far. But it seems to work properly.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    not affected    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [  ✅  ] I have tested this on a device and a simulator
- [ not needed ] I added the documentation in `README.md`
- [ might not be needed ] I mentioned this change in `CHANGELOG.md`
- [ not needed ] I updated the typed files (TS and Flow)
- [ not needed ] I added a sample use of the API in the example project (`example/App.js`)
