### PR TITLE
feat(new prop): containerStyle

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -25,6 +25,7 @@ This document lays out the current public properties and methods for the React N
 - [`onShouldStartLoadWithRequest`](Reference.md#onshouldstartloadwithrequest)
 - [`startInLoadingState`](Reference.md#startinloadingstate)
 - [`style`](Reference.md#style)
+- [`containerStyle`](Reference.md#containerStyle)
 - [`decelerationRate`](Reference.md#decelerationrate)
 - [`domStorageEnabled`](Reference.md#domstorageenabled)
 - [`javaScriptEnabled`](Reference.md#javascriptenabled)
@@ -343,6 +344,7 @@ url
 ### `onHttpError`
 
 Function that is invoked when the `WebView` receives an http error.
+
 > **_Note_**
 > Android API minimum level 23.
 
@@ -357,7 +359,10 @@ Example:
   source={{ uri: 'https://facebook.github.io/react-native' }}
   onHttpError={syntheticEvent => {
     const { nativeEvent } = syntheticEvent;
-    console.warn('WebView received error status code: ', nativeEvent.statusCode);
+    console.warn(
+      'WebView received error status code: ',
+      nativeEvent.statusCode,
+    );
   }}
 />
 ```
@@ -446,7 +451,7 @@ Example:
   onContentProcessDidTerminate={syntheticEvent => {
     const { nativeEvent } = syntheticEvent;
     console.warn('Content process terminated, reloading', nativeEvent);
-    this.refs.webview.reload()
+    this.refs.webview.reload();
   }}
 />
 ```
@@ -597,6 +602,25 @@ Example:
 <WebView
   source={{ uri: 'https://facebook.github.io/react-native' }}
   style={{ marginTop: 20 }}
+/>
+```
+
+---
+
+### `containerStyle`
+
+A style object that allow you to customize the `WebView` container style. Please note that there are default styles (example: you need to add `flex: 0` to the style if you want to use `height` property).
+
+| Type  | Required |
+| ----- | -------- |
+| style | No       |
+
+Example:
+
+```jsx
+<WebView
+  source={{ uri: 'https://facebook.github.io/react-native' }}
+  containerStyle={{ marginTop: 20 }}
 />
 ```
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -249,6 +249,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
       renderLoading,
       source,
       style,
+      containerStyle,
       nativeConfig = {},
       ...otherProps
     } = this.props;
@@ -272,6 +273,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     }
 
     const webViewStyles = [styles.container, styles.webView, style];
+    const webViewContainerStyle = [styles.container, containerStyle];
 
     if (source && 'method' in source) {
       if (source.method === 'POST' && source.headers) {
@@ -314,7 +316,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     );
 
     return (
-      <View style={styles.container}>
+      <View style={webViewContainerStyle}>
         {webView}
         {otherView}
       </View>

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -291,6 +291,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
       renderError,
       renderLoading,
       style,
+      containerStyle,
       ...otherProps
     } = this.props;
 
@@ -313,6 +314,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     }
 
     const webViewStyles = [styles.container, styles.webView, style];
+    const webViewContainerStyle = [styles.container, containerStyle];
 
     const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
       this.onShouldStartLoadWithRequestCallback,
@@ -351,7 +353,7 @@ class WebView extends React.Component<IOSWebViewProps, State> {
     );
 
     return (
-      <View style={styles.container}>
+      <View style={webViewContainerStyle}>
         {webView}
         {otherView}
       </View>

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -4,6 +4,8 @@ import { ReactElement, Component } from 'react';
 import {
   NativeSyntheticEvent,
   ViewProps,
+  StyleProp,
+  ViewStyle,
   NativeMethodsMixin,
   Constructor,
   UIManagerStatic,
@@ -575,6 +577,11 @@ export interface WebViewSharedProps extends ViewProps {
    * @platform android
    */
   javaScriptEnabled?: boolean;
+
+  /**
+   * Stylesheet object to set the style of the container view.
+   */
+  containerStyle?: StyleProp<ViewStyle>;
 
   /**
    * Function that returns a view to show if there's an error.


### PR DESCRIPTION
# Summary

Me and my team need to use the `WebView` to display error from server (in HTML format) inside modals.
The `flex: 1` in the container style doesn't allow us to style the modal as the UX/UI team wants to.

With this `prop` we can set `flex: 0` and style the container and the `WebView` as we want.

## Test Plan

`yarn ci` runs without any issue.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
