### PR TITLE
fix(android): renderError - the error status might be overwritten by loading progress event

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -218,8 +218,11 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     const { onLoadProgress } = this.props;
     const { nativeEvent: { progress } } = event;
     if (progress === 1) {
-      this.setState({
-        viewState: 'IDLE',
+      this.setState((state) => {
+        if (state.viewState === 'LOADING') {
+          return { viewState: 'IDLE' };
+        }
+        return null;
       });
     }
     if (onLoadProgress) {


### PR DESCRIPTION
# Summary

It might still trigger loading progress event (to 100/100) after error being received in Android WebView. As a result, the previous `ERROR` state will be overwritten to `IDLE` in `onLoadingProgress()` and the view created by `renderError()` won't be visible in this case.


## Test Plan

### What are the steps to reproduce (after prerequisites)?
- use the WebView with `renderError` props set
- set a incorrect url to load - e.g. http://www.google.com1
- check if the `renderError` contents are visible

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
