### PR TITLE
modify ios library for exposing header file

### DIFF
--- a/ios/RNCWebView.xcodeproj/project.pbxproj
+++ b/ios/RNCWebView.xcodeproj/project.pbxproj
@@ -10,16 +10,26 @@
 		3515965E21A3C86000623BFA /* RNCWKProcessPoolManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3515965D21A3C86000623BFA /* RNCWKProcessPoolManager.m */; };
 		E91B351D21446E6C00F9801F /* RNCWebViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E91B351B21446E6C00F9801F /* RNCWebViewManager.m */; };
 		E91B351E21446E6C00F9801F /* RNCWebView.m in Sources */ = {isa = PBXBuildFile; fileRef = E91B351C21446E6C00F9801F /* RNCWebView.m */; };
+		FA3FFD6D2362A14A00B5B551 /* RNCWebView.h in Copy Files */ = {isa = PBXBuildFile; fileRef = E91B351A21446E6C00F9801F /* RNCWebView.h */; };
+		FA3FFD6E2362A14A00B5B551 /* RNCWebViewManager.h in Copy Files */ = {isa = PBXBuildFile; fileRef = E91B351921446E6C00F9801F /* RNCWebViewManager.h */; };
+		FA3FFD6F2362A14A00B5B551 /* RNCWKProcessPoolManager.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 3515965F21A3C87E00623BFA /* RNCWKProcessPoolManager.h */; };
+		FA3FFD712362A17300B5B551 /* RNCWebView.h in Headers */ = {isa = PBXBuildFile; fileRef = E91B351A21446E6C00F9801F /* RNCWebView.h */; };
+		FA3FFD722362A17300B5B551 /* RNCWebViewManager.h in Headers */ = {isa = PBXBuildFile; fileRef = E91B351921446E6C00F9801F /* RNCWebViewManager.h */; };
+		FA3FFD732362A17400B5B551 /* RNCWKProcessPoolManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3515965F21A3C87E00623BFA /* RNCWKProcessPoolManager.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+		58B511D91A9E6C8500147676 /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				FA3FFD6D2362A14A00B5B551 /* RNCWebView.h in Copy Files */,
+				FA3FFD6E2362A14A00B5B551 /* RNCWebViewManager.h in Copy Files */,
+				FA3FFD6F2362A14A00B5B551 /* RNCWKProcessPoolManager.h in Copy Files */,
 			);
+			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -68,14 +78,28 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		FA3FFD702362A16A00B5B551 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA3FFD712362A17300B5B551 /* RNCWebView.h in Headers */,
+				FA3FFD722362A17300B5B551 /* RNCWebViewManager.h in Headers */,
+				FA3FFD732362A17400B5B551 /* RNCWKProcessPoolManager.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		58B511DA1A9E6C8500147676 /* RNCWebView */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RNCWebView" */;
 			buildPhases = (
+				FA3FFD702362A16A00B5B551 /* Headers */,
+				58B511D91A9E6C8500147676 /* Copy Files */,
 				58B511D71A9E6C8500147676 /* Sources */,
 				58B511D81A9E6C8500147676 /* Frameworks */,
-				58B511D91A9E6C8500147676 /* CopyFiles */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
# Summary

I want to extends RNCWebView class for supporting refreshing, but when I link react-native-webivew in my project by manual, the header file of  RNCWebView.h and RNCWebViewManager.h are not found like that:
![image](https://user-images.githubusercontent.com/17615716/67541939-55605680-f71d-11e9-90ce-61a72e6265cc.png)

for this problem, I found the RNCWebView.xcodeproj dose not expose header file. 
![image](https://user-images.githubusercontent.com/17615716/67545935-7630a800-f72d-11e9-951b-438638cc7d58.png)

I think this pull request is useful to extends WebView's function

## Test Plan

[example](https://github.com/openUmbrella/react-native-mjrefresh-ios/tree/master/example)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)