### PR TITLE
Implementing minimumFontSize for Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -232,6 +232,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     view.getSettings().setJavaScriptEnabled(enabled);
   }
 
+  @ReactProp(name = "minimumFontSize")
+  public void setMinimumFontSize(WebView view, int fontSize) {
+    view.getSettings().setMinimumFontSize(fontSize);
+  }
+
   @ReactProp(name = "showsHorizontalScrollIndicator")
   public void setShowsHorizontalScrollIndicator(WebView view, boolean enabled) {
     view.setHorizontalScrollBarEnabled(enabled);

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -61,6 +61,7 @@ This document lays out the current public properties and methods for the React N
 - [`allowsLinkPreview`](Reference.md#allowsLinkPreview)
 - [`sharedCookiesEnabled`](Reference.md#sharedCookiesEnabled)
 - [`textZoom`](Reference.md#textZoom)
+- [`minimumFontSize`](Reference.md#minimumFontSize)
 
 ## Methods Index
 
@@ -1056,6 +1057,20 @@ When setting the standard textZoom (100) parameter size, this undesirable effect
 Example:
 
 `<WebView textZoom={100} />`
+
+---
+
+### `minimumFontSize`
+
+Android enforces a minimum font size based on this value. Default value is 8. If you are using smaller font sizes and are having trouble fitting the whole window onto one screen, try setting this to a smaller value. 
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | Android  |
+
+Example:
+
+`<WebView minimumFontSize={1} />`
 
 ## Methods
 


### PR DESCRIPTION
# Summary

Android WebView enforces a default minimum font size of 8 (see https://developer.android.com/reference/android/webkit/WebSettings#setMinimumFontSize(int)), causing scaling issues when using smaller font sizes. Content that may be deliberately scaled down to fit 100% width of the device may overflow. This property allows for customizing the minimum font size so scaling appears similar as on iOS. 

In cases where grids of content/text are displayed (such as a seating chart), font size may need to be scaled down to fit the entire grid onto one screen width.

## Test Plan

### What's required for testing (prerequisites)?

Running on Android.

### What are the steps to reproduce (after prerequisites)?

Reference HTML code that uses font sizes < 8. For example:

`
<WebView source={{ html: '<html><body><span style="font-size: 4px;">Font size 4</span></body></html>' }} minimumFontSize={1} />
`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `Reference.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
