### PR TITLE
Fix ClassCastException

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -1002,7 +1002,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     @Override
     public void setWebViewClient(WebViewClient client) {
       super.setWebViewClient(client);
-      mRNCWebViewClient = (RNCWebViewClient) client;
+      if (client instanceof RNCWebViewClient) {
+        mRNCWebViewClient = (RNCWebViewClient) client;
+      }
     }
 
     public @Nullable


### PR DESCRIPTION
# Summary
A ClassCastException occurs when setWebViewClient() is called on Android native.
I access the RN webview on Android native by casting to an Android webview to add custom functionality. Calling setWebViewClient() thereafter caused a ClassCastException.

## Test Plan

### What's required for testing (prerequisites)?
Running on Android

### What are the steps to reproduce (after prerequisites)?
1. Access the RN webview object on Android
2. Cast to Android WebView
3. Call setWebViewClient()

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
