### PR TITLE
Fixed Android's source 'url'

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -421,8 +421,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         view.loadDataWithBaseURL(baseUrl, html, HTML_MIME_TYPE, HTML_ENCODING, null);
         return;
       }
-      if (source.hasKey("uri")) {
-        String url = source.getString("uri");
+      if (source.hasKey("uri") || source.hasKey("url")) {
+        String url = source.getString("uri") || source.getString("url");
         String previousUrl = view.getUrl();
         if (previousUrl != null && previousUrl.equals(url)) {
           return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Android source 'url' fix

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

I decided to make this pull request, as I struggled with the issue for over 3 hours until i found this issue #988

When loading a url in your source props, both ``uri`` and ``url`` works on iOS, but on android only ``uri`` works. There were no error message telling me that, so i fixed the compatibility issue.

## Compatibility with both ``uri`` and ``url``

Before my Pull Request:

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅✅     |
| Android |    ✅❌   |

With my Pull Request:

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅✅     |
| Android |    ✅✅   |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
