### PR TITLE
chore(buildtools): Use fixed version of cocoapods gem on ci

### DIFF
--- a/.github/workflows/detox.yml
+++ b/.github/workflows/detox.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Setup - Install NPM Dependencies
         run: yarn
       - name: Setup - Install CocoaPods CLI
-        run: sudo gem install cocoapods
+        run: sudo gem install cocoapods -v 1.8.4
       - name: Run tests
         run: yarn ci


### PR DESCRIPTION
install exact version instead of latest one

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
I added exact version for `gem install` in order to make CI more stable.
v 1.8.4 is the latest one and being used currently in this project.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
- [ ] ci is green

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
