### PR TITLE
chore(docs): Steps to load local HTML files into the webview

### DIFF
--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -8,6 +8,7 @@ _This guide is currently a work in progress._
 
 - [Basic Inline HTML](Guide.md#basic-inline-html)
 - [Basic URL Source](Guide.md#basic-url-source)
+- [Loading local HTML files](Guide.md#loading-local-html-files)
 - [Controlling navigation state changes](Guide.md#controlling-navigation-state-changes)
 - [Add support for File Upload](Guide.md#add-support-for-file-upload)
 - [Multiple files upload](Guide.md#multiple-files-upload)
@@ -49,6 +50,40 @@ class MyWeb extends Component {
   render() {
     return (
       <WebView source={{ uri: 'https://facebook.github.io/react-native/' }} />
+    );
+  }
+}
+```
+
+### Loading local HTML files
+
+Sometimes you would have bundled an HTML file along with the app and would like to load the HTML asset into your WebView. To do this on iOS, you can just import the html file like any other asset as shown below.
+
+```js
+import React, { Component } from 'react';
+import { WebView } from 'react-native-webview';
+
+const myHtmlFile = require("./my-asset-folder/local-site.html");
+
+class MyWeb extends Component {
+  render() {
+    return (
+      <WebView source={myHtmlFile} />
+    );
+  }
+}
+```
+
+However on Android, you need to place the HTML file inside your android project's asset directory. For example, if `local-site.html` is your HTML file and you'd like to load it into the webview, you should move the file to your project's android asset directory which is `your-project/android/src/main/assets/`. Then you can load the html file as shown in the following code block
+
+```js
+import React, { Component } from 'react';
+import { WebView } from 'react-native-webview';
+
+class MyWeb extends Component {
+  render() {
+    return (
+      <WebView source={{ uri: "file:///android_asset/local-site.html" }} />
     );
   }
 }


### PR DESCRIPTION
Fixes #746 

# Summary
These steps are based on my other project React native draftjs which requires loading a local HTML file. The code can be found in the following line - https://github.com/DaniAkash/react-native-draftjs/blob/bc51410117d238e0f67f90e614fe11aacf41843b/index.js#L113

## Test Plan

There is a project implement using this method - [React Native Draftjs](https://github.com/DaniAkash/react-native-draftjs) which can be referred for proper functioning of this feature.

### What's required for testing (prerequisites)?

A simple html and loading in the webview will do.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
