### PR TITLE
fix(android): crash problem while loading local html resource

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -278,7 +278,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     const webViewStyles = [styles.container, styles.webView, style];
     const webViewContainerStyle = [styles.container, containerStyle];
 
-    if (source && 'method' in source) {
+    if (typeof source !== "number" && source && 'method' in source) {
       if (source.method === 'POST' && source.headers) {
         console.warn(
           'WebView: `source.headers` is not supported when using POST.',


### PR DESCRIPTION
## Summary
this commits is try to resolve the crash problem while use 'require(./XXX.html)' to load local html, 
such as:

![QQ截图20191111103900](https://user-images.githubusercontent.com/17643700/68557027-8788ec80-046f-11ea-8d69-13ad97e78a04.png)

## What are the steps to reproduce (after prerequisites)?
```
render(){
      const uri = require('../../Resources/index.html')

     <WebView
          style={styles.webview}
          originWhitelist={['*']}
          source={uri}   
        />
}
```
## Test Plan

What's required for testing (prerequisites)?
Running on Android

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅   |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
