### PR TITLE
Focus webview after source changes

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -468,6 +468,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           }
         }
         view.loadUrl(url, headerMap);
+        view.requestFocus();
         return;
       }
     }


### PR DESCRIPTION
# Summary

Implements the suggestion from https://github.com/react-native-community/react-native-webview/issues/366 (in which you would be unable to interact with the webview with a remote on Android TV, because the webview wasn't focused). This fix should focus the webview whenever the `source` prop changes.

This fix is only for Android. I'm not sure whether or not this is an issue on iOS, and I don't have the means to test on an Apple TV. I've tested this on a device (NVIDIA Shield TV).

## Test Plan

### What's required for testing (prerequisites)?

- Android TV (I'm using an NVIDIA Shield TV, but this probably works with others as well)
- TV remote

### What are the steps to reproduce (after prerequisites)?

Once the webview loads, you should be able to interact with it with the remote (left and right tab through links/inputs as if on a keyboard, "OK" button clicks)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device ~~and a simulator~~
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
