### PR TITLE
fix(android): Added fallback poster image to prevent crashes

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -643,6 +643,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       int initialRequestedOrientation = reactContext.getCurrentActivity().getRequestedOrientation();
       mWebChromeClient = new RNCWebChromeClient(reactContext, webView) {
         @Override
+        public Bitmap getDefaultVideoPoster() {
+          return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
+        }
+        
+        @Override
         public void onShowCustomView(View view, CustomViewCallback callback) {
           if (mVideoView != null) {
             callback.onCustomViewHidden();
@@ -694,7 +699,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       if (mWebChromeClient != null) {
         mWebChromeClient.onHideCustomView();
       }
-      mWebChromeClient = new RNCWebChromeClient(reactContext, webView);
+      mWebChromeClient = new RNCWebChromeClient(reactContext, webView) {
+        @Override
+        public Bitmap getDefaultVideoPoster() {
+          return Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
+        }
+      };
       webView.setWebChromeClient(mWebChromeClient);
     }
   }


### PR DESCRIPTION
# Summary
Fixes crash when HTML5 video doesn't have post image, link to issue:
https://github.com/react-native-community/react-native-webview/issues/1026

## Checklist
- [x ] I have tested this on a device and a simulator
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.js`)
