### PR TITLE
add allowFileAccessFromFileURLs property on iOS

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -884,9 +884,9 @@ Set whether Geolocation is enabled in the `WebView`. The default value is `false
 
 Boolean that sets whether JavaScript running in the context of a file scheme URL should be allowed to access content from other file scheme URLs. The default value is `false`.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
+| Type | Required |
+| ---- | -------- |
+| bool | No       |
 
 ---
 

--- a/ios/RNCWebView.h
+++ b/ios/RNCWebView.h
@@ -40,6 +40,7 @@
 @property (nonatomic, assign) BOOL keyboardDisplayRequiresUserAction;
 @property (nonatomic, assign) BOOL hideKeyboardAccessoryView;
 @property (nonatomic, assign) BOOL allowsBackForwardNavigationGestures;
+@property (nonatomic, assign) BOOL allowFileAccessFromFileURLs;
 @property (nonatomic, assign) BOOL incognito;
 @property (nonatomic, assign) BOOL useSharedProcessPool;
 @property (nonatomic, copy) NSString * _Nullable userAgent;

--- a/ios/RNCWebView.m
+++ b/ios/RNCWebView.m
@@ -151,7 +151,7 @@ static NSDictionary* customCertificatesForHost;
       wkWebViewConfig.processPool = [[RNCWKProcessPoolManager sharedManager] sharedProcessPool];
     }
     wkWebViewConfig.userContentController = [WKUserContentController new];
-
+      
     if (_messagingEnabled) {
       [wkWebViewConfig.userContentController addScriptMessageHandler:self name:MessageHandlerName];
 
@@ -241,6 +241,10 @@ static NSDictionary* customCertificatesForHost;
                                                            forMainFrameOnly:YES];
         [wkWebViewConfig.userContentController addUserScript:cookieInScript];
       }
+    }
+      
+    if (_allowFileAccessFromFileURLs) {
+        [wkWebViewConfig.preferences setValue:@YES forKey:@"allowFileAccessFromFileURLs"];
     }
 
     _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];

--- a/ios/RNCWebViewManager.m
+++ b/ios/RNCWebViewManager.m
@@ -128,6 +128,10 @@ RCT_CUSTOM_VIEW_PROPERTY(keyboardDisplayRequiresUserAction, BOOL, RNCWebView) {
   view.keyboardDisplayRequiresUserAction = json == nil ? true : [RCTConvert BOOL: json];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(allowFileAccessFromFileURLs, BOOL, RNCWebView) {
+    view.allowFileAccessFromFileURLs = json == nil ? false : [RCTConvert BOOL: json];
+}
+
 RCT_EXPORT_METHOD(injectJavaScript:(nonnull NSNumber *)reactTag script:(NSString *)script)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNCWebView *> *viewRegistry) {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -236,13 +236,13 @@ export interface CommonNativeWebViewProps extends ViewProps {
    * Append to the existing user-agent. Overriden if `userAgent` is set.
    */
   applicationNameForUserAgent?: string;
+  allowFileAccessFromFileURLs?: boolean;
 }
 
 export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   cacheMode?: CacheMode;
   allowFileAccess?: boolean;
   scalesPageToFit?: boolean;
-  allowFileAccessFromFileURLs?: boolean;
   allowUniversalAccessFromFileURLs?: boolean;
   androidHardwareAccelerationDisabled?: boolean;
   domStorageEnabled?: boolean;
@@ -501,15 +501,6 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    */
   geolocationEnabled?: boolean;
 
-
-  /**
-   * Boolean that sets whether JavaScript running in the context of a file
-   * scheme URL should be allowed to access content from other file scheme URLs.
-   * Including accessing content from other file scheme URLs
-   * @platform android
-   */
-  allowFileAccessFromFileURLs?: boolean;
-
   /**
    * Boolean that sets whether JavaScript running in the context of a file
    * scheme URL should be allowed to access content from any origin.
@@ -729,4 +720,12 @@ export interface WebViewSharedProps extends ViewProps {
    * Should caching be enabled. Default is true.
    */
   cacheEnabled?: boolean;
+
+
+  /**
+   * Boolean that sets whether JavaScript running in the context of a file
+   * scheme URL should be allowed to access content from other file scheme URLs.
+   * Including accessing content from other file scheme URLs
+   */
+  allowFileAccessFromFileURLs?: boolean;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Similar to the work done in https://github.com/react-native-community/react-native-webview/pull/831, it is not possible to render a local HTML file on iOS. For this to be possible `allowFileAccessFromFileURLs` has to be set to true.

This PR adds a new property, and sets it on the `WKPreferences` object before the webview is created.

## Test Plan

### What's required for testing (prerequisites)?

- Attempt to load a local HTML file that in turn loads other files in the bundle (JS, etc)

### What are the steps to reproduce (after prerequisites)?

- Attempt to load a local HTML file that in turn loads other files in the bundle (JS, etc)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ in this PR     |
| Android |    ✅ previously    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
-- Is there a CHANGELOG?
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
-- Is there an example project?
