### PR TITLE
Two tweaks to how URLs from un-whitelisted origins are handled

### DIFF
--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -44,7 +44,15 @@ const createOnShouldStartLoadWithRequest = (
     const { url, lockIdentifier } = nativeEvent;
 
     if (!passesWhitelist(compileWhitelist(originWhitelist), url)) {
-      Linking.openURL(url);
+      Linking.canOpenURL(url).then((supported) => {
+        if (supported) {
+          return Linking.openURL(url);
+        }
+        console.warn(`Can't open url: ${url}`);
+        return undefined;
+      }).catch(e => {
+        console.warn('Error opening URL: ', e);
+      });
       shouldStart = false;
     }
 

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -54,9 +54,7 @@ const createOnShouldStartLoadWithRequest = (
         console.warn('Error opening URL: ', e);
       });
       shouldStart = false;
-    }
-
-    if (onShouldStartLoadWithRequest) {
+    } else if (onShouldStartLoadWithRequest) {
       shouldStart = onShouldStartLoadWithRequest(nativeEvent);
     }
 

--- a/src/__tests__/WebViewShared-test.js
+++ b/src/__tests__/WebViewShared-test.js
@@ -102,7 +102,9 @@ describe('WebViewShared', () => {
       await flushPromises();
 
       expect(Linking.openURL).toHaveBeenLastCalledWith('invalid://example.com/');
-      expect(loadRequest).toHaveBeenLastCalledWith(true, 'invalid://example.com/', 1);
+      // We don't expect the URL to have been loaded in the WebView because it
+      // is not in the origin whitelist
+      expect(loadRequest).toHaveBeenLastCalledWith(false, 'invalid://example.com/', 1);
     });
 
     test('loadRequest with false onShouldStartLoadWithRequest override is called', async () => {

--- a/src/__tests__/WebViewShared-test.js
+++ b/src/__tests__/WebViewShared-test.js
@@ -5,6 +5,31 @@ import {
   createOnShouldStartLoadWithRequest,
 } from '../WebViewShared';
 
+Linking.openURL.mockResolvedValue(undefined);
+Linking.canOpenURL.mockResolvedValue(true);
+
+// The tests that call createOnShouldStartLoadWithRequest will cause a promise
+// to get kicked off (by calling the mocked `Linking.canOpenURL`) that the tests
+// _need_ to get run to completion _before_ doing any `expect`ing. The reason
+// is: once that promise is resolved another function should get run which will
+// call `Linking.openURL`, and we want to test that.
+//
+// Normally we would probably do something like `await
+// createShouldStartLoadWithRequest(...)` in the tests, but that doesn't work
+// here because the promise that gets kicked off is not returned (because
+// non-test code doesn't need to know about it).
+//
+// The tests thus need a way to "flush any pending promises" (to make sure
+// pending promises run to completion) before doing any `expect`ing. `jest`
+// doesn't provide a way to do this out of the box, but we can use this function
+// to do it.
+//
+// See this issue for more discussion: https://github.com/facebook/jest/issues/2157
+function flushPromises() {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+
 describe('WebViewShared', () => {
   test('exports defaultOriginWhitelist', () => {
     expect(defaultOriginWhitelist).toMatchSnapshot();
@@ -21,29 +46,35 @@ describe('WebViewShared', () => {
 
     const loadRequest = jest.fn();
 
-    test('loadRequest is called without onShouldStartLoadWithRequest override', () => {
+    test('loadRequest is called without onShouldStartLoadWithRequest override', async () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://www.example.com/', lockIdentifier: 1 } });
+      
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenCalledTimes(0);
       expect(loadRequest).toHaveBeenCalledWith(true, 'https://www.example.com/', 1);
     });
 
-    test('Linking.openURL is called without onShouldStartLoadWithRequest override', () => {
+    test('Linking.openURL is called without onShouldStartLoadWithRequest override', async () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'invalid://example.com/', lockIdentifier: 2 } });
+      
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenCalledWith('invalid://example.com/');
       expect(loadRequest).toHaveBeenCalledWith(false, 'invalid://example.com/', 2);
     });
 
-    test('loadRequest with true onShouldStartLoadWithRequest override is called', () => {
+    test('loadRequest with true onShouldStartLoadWithRequest override is called', async () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
@@ -51,23 +82,30 @@ describe('WebViewShared', () => {
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://www.example.com/', lockIdentifier: 1 } });
+
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenCalledTimes(0);
       expect(loadRequest).toHaveBeenLastCalledWith(true, 'https://www.example.com/', 1);
     });
 
-    test('Linking.openURL with true onShouldStartLoadWithRequest override is called for links not passing the whitelist', () => {
+    test('Linking.openURL with true onShouldStartLoadWithRequest override is called for links not passing the whitelist', async () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
         alwaysTrueOnShouldStartLoadWithRequest,
       );
 
+      var a = 10;
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'invalid://example.com/', lockIdentifier: 1 } });
+
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenLastCalledWith('invalid://example.com/');
       expect(loadRequest).toHaveBeenLastCalledWith(true, 'invalid://example.com/', 1);
     });
 
-    test('loadRequest with false onShouldStartLoadWithRequest override is called', () => {
+    test('loadRequest with false onShouldStartLoadWithRequest override is called', async () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
@@ -75,60 +113,92 @@ describe('WebViewShared', () => {
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://www.example.com/', lockIdentifier: 1 } });
+
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenCalledTimes(0);
       expect(loadRequest).toHaveBeenLastCalledWith(false, 'https://www.example.com/', 1);
     });
 
-    test('loadRequest with limited whitelist', () => {
+    test('loadRequest with limited whitelist', async () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         ['https://*'],
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://www.example.com/', lockIdentifier: 1 } });
+      
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenCalledTimes(0);
       expect(loadRequest).toHaveBeenLastCalledWith(true, 'https://www.example.com/', 1);
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'http://insecure.com/', lockIdentifier: 2 } });
+
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenLastCalledWith('http://insecure.com/');
       expect(loadRequest).toHaveBeenLastCalledWith(false, 'http://insecure.com/', 2);
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'git+https://insecure.com/', lockIdentifier: 3 } });
+      
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenLastCalledWith('git+https://insecure.com/');
       expect(loadRequest).toHaveBeenLastCalledWith(false, 'git+https://insecure.com/', 3);
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'fakehttps://insecure.com/', lockIdentifier: 4 } });
+      
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenLastCalledWith('fakehttps://insecure.com/');
       expect(loadRequest).toHaveBeenLastCalledWith(false, 'fakehttps://insecure.com/', 4);
     });
 
-    test('loadRequest allows for valid URIs', () => {
+    test('loadRequest allows for valid URIs', async () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
           loadRequest,
           ['plus+https://*', 'DOT.https://*', 'dash-https://*', '0invalid://*', '+invalid://*'],
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'plus+https://www.example.com/', lockIdentifier: 1 } });
+      
+      await flushPromises();
       expect(Linking.openURL).toHaveBeenCalledTimes(0);
       expect(loadRequest).toHaveBeenLastCalledWith(true, 'plus+https://www.example.com/', 1);
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'DOT.https://www.example.com/', lockIdentifier: 2 } });
+
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenCalledTimes(0);
       expect(loadRequest).toHaveBeenLastCalledWith(true, 'DOT.https://www.example.com/', 2);
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'dash-https://www.example.com/', lockIdentifier: 3 } });
+      
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenCalledTimes(0);
       expect(loadRequest).toHaveBeenLastCalledWith(true, 'dash-https://www.example.com/', 3);
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: '0invalid://www.example.com/', lockIdentifier: 4 } });
+
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenLastCalledWith('0invalid://www.example.com/');
       expect(loadRequest).toHaveBeenLastCalledWith(false, '0invalid://www.example.com/', 4);
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: '+invalid://www.example.com/', lockIdentifier: 5 } });
+      
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenLastCalledWith('+invalid://www.example.com/');
       expect(loadRequest).toHaveBeenLastCalledWith(false, '+invalid://www.example.com/', 5);
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'FAKE+plus+https://www.example.com/', lockIdentifier: 6 } });
+
+      await flushPromises();
+
       expect(Linking.openURL).toHaveBeenLastCalledWith('FAKE+plus+https://www.example.com/');
       expect(loadRequest).toHaveBeenLastCalledWith(false, 'FAKE+plus+https://www.example.com/', 6);
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR does two pretty small and related things (in two commits):

## 1. Preventing an Unhandled Promise Rejection
When the WebView tries to load a URL from an un-whitelisted origin, react-native-webview calls `Linking.openURL` and lets the OS handle it.  But, sometimes there is an error on the native side of `Linking.openURL`, for example on Android if the URL is like `intent://....` but there is no Activity that can handle that intent installed.  This results in an unhandled promise rejection because no code is `catch`ing the error. 

We track and handle unhandled promise rejections in our app, and send them to our crash/analytics service as errors.  This is not _really_ an error though, so its just noise.  Actually another concern is that it possibly has user info (in the URL) that we don't want to be storing either.  

Anyways, the simple fix is to add a `.catch(() => {})` when we call `Linking.openURL` so errors, if any, are simply ignored and not sent to our unhandled promise rejection handler.

## 2. Prevent both the library and the app from handling un-whitelisted URLs

Another thing about the scenario described above, is that react-native-webview will call `Linking.openURL` and then _still_ call our `onShouldStartLoadWithRequest` handler.  The result of  `onShouldStartLoadWithRequest` then overrides whether or not the URL should get loaded.

This results in a scenario where a URL from an un-whitelisted origin is handled by the OS (via the call to `Linking.openURL`) *AND* loaded into the WebView because the custom `onShouldStartLoadWithRequest` returns `true`.

The app can work around this by doing the whitelist origin checks itself in `onShouldStartLoadWithRequest` but that feels like a worse solution because every client that uses `onShouldStartLoadWithRequest` would have to do it or have this subtle bug (albeit its definitely an edge-case).

Anyways, the fix is to just say that if a URL is from an un-whitelisted origin, _dont_ call `onShouldStartLoadWithRequest`.  Just call `Linking.openURL` and let the OS handle it, and _dont_ load it in the WebView.

This might be more controversial since it is technically a breaking change (and I had to update a test for it).

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

For the first thing just exercising loading a non-whitelisted URL in the WebView that causes an OS error (e.g. the `intent://...` style URLs on Android).  Without this change you will get an unhandled promise rejection error.  With it you won't.

I did that and verified there was no error.

For the second thing, also implement a `onShouldStartLoadWithRequest` function that gets passed to the WebView and that returns true for everything.  Without this change following a URL to an un-whitelisted origin, e.g. un-whitelist `http://` and follow a link to a `http://` URL, will result in the OS opening the system browser for the URL as well as it getting loaded in the WebView.  With this change it will just get opened by the OS in the system browser.

I did that as well, and verified that the URL is just handed off to the OS and not `onShouldStartLoadWithRequest`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [sorta] I have tested this on a device and a simulator // I tested on an Android simulator
- [no] I added the documentation in `README.md` // Not sure it needs to be documented?  Happy to update it though.
- [not yet] I mentioned this change in `CHANGELOG.md`// Wanted to make sure this seemed ok first 
- [X] I updated the typed files (TS and Flow)
- [no] I added a sample use of the API in the example project (`example/App.js`) // Didn't seem necessary.
