### PR TITLE
feat(ios): Generate history API events on iOS

### DIFF
--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -149,44 +149,6 @@ class MyWeb extends Component {
 }
 ```
 
-#### Intercepting hash URL changes
-
-While `onNavigationStateChange` will trigger on URL changes, it does not trigger when only the hash URL ("anchor") changes, e.g. from `https://example.com/users#list` to `https://example.com/users#help`.
-
-You can inject some JavaScript to wrap the history functions in order to intercept these hash URL changes.
-
-```jsx
-<WebView
-  source={{ uri: someURI }}
-  injectedJavaScript={`
-    (function() {
-      function wrap(fn) {
-        return function wrapper() {
-          var res = fn.apply(this, arguments);
-          window.ReactNativeWebView.postMessage('navigationStateChange');
-          return res;
-        }
-      }
-
-      history.pushState = wrap(history.pushState);
-      history.replaceState = wrap(history.replaceState);
-      window.addEventListener('popstate', function() {
-        window.ReactNativeWebView.postMessage('navigationStateChange');
-      });
-    })();
-
-    true;
-  `}
-  onMessage={({ nativeEvent: state }) => {
-    if (state.data === 'navigationStateChange') {
-      // Navigation state updated, can check state.canGoBack, etc.
-    }
-  }}
-/>
-```
-
-Thanks to [Janic Duplessis](https://github.com/react-native-community/react-native-webview/issues/24#issuecomment-483956651) for this workaround.
-
 ### Add support for File Upload
 
 ##### iOS

--- a/ios/RNCWebView.m
+++ b/ios/RNCWebView.m
@@ -14,6 +14,7 @@
 #import "objc/runtime.h"
 
 static NSTimer *keyboardTimer;
+static NSString *const HistoryShimName = @"ReactNativeHistoryShim";
 static NSString *const MessageHandlerName = @"ReactNativeWebView";
 static NSURLCredential* clientAuthenticationCredential;
 static NSDictionary* customCertificatesForHost;
@@ -159,6 +160,31 @@ static NSDictionary* customCertificatesForHost;
       wkWebViewConfig.processPool = [[RNCWKProcessPoolManager sharedManager] sharedProcessPool];
     }
     wkWebViewConfig.userContentController = [WKUserContentController new];
+
+    // Shim the HTML5 history API:
+    [wkWebViewConfig.userContentController addScriptMessageHandler:self name:HistoryShimName];
+    NSString *source = [NSString stringWithFormat:
+      @"(function(history) {\n"
+      "  function notify(type) {\n"
+      "    setTimeout(function() {\n"
+      "      window.webkit.messageHandlers.%@.postMessage(type)\n"
+      "    }, 0)\n"
+      "  }\n"
+      "  function shim(f) {\n"
+      "    return function pushState() {\n"
+      "      notify('other')\n"
+      "      return f.apply(history, arguments)\n"
+      "    }\n"
+      "  }\n"
+      "  history.pushState = shim(history.pushState)\n"
+      "  history.replaceState = shim(history.replaceState)\n"
+      "  window.addEventListener('popstate', function() {\n"
+      "    notify('backforward')\n"
+      "  })\n"
+      "})(window.history)\n", HistoryShimName
+    ];
+    WKUserScript *script = [[WKUserScript alloc] initWithSource:source injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
+    [wkWebViewConfig.userContentController addUserScript:script];
 
     if (_messagingEnabled) {
       [wkWebViewConfig.userContentController addScriptMessageHandler:self name:MessageHandlerName];
@@ -404,10 +430,18 @@ static NSDictionary* customCertificatesForHost;
 - (void)userContentController:(WKUserContentController *)userContentController
        didReceiveScriptMessage:(WKScriptMessage *)message
 {
-  if (_onMessage != nil) {
-    NSMutableDictionary<NSString *, id> *event = [self baseEvent];
-    [event addEntriesFromDictionary: @{@"data": message.body}];
-    _onMessage(event);
+  if ([message.name isEqualToString:HistoryShimName]) {
+    if (_onLoadingFinish) {
+      NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+      [event addEntriesFromDictionary: @{@"navigationType": message.body}];
+      _onLoadingFinish(event);
+    }
+  } else if ([message.name isEqualToString:MessageHandlerName]) {
+    if (_onMessage) {
+      NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+      [event addEntriesFromDictionary: @{@"data": message.body}];
+      _onMessage(event);
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Resolving merge conflicts for https://github.com/react-native-community/react-native-webview/pull/652

> This pull request solves #24, where navigating the WebView using the window.history API doesn't generate any events on iOS. This seems to be a low-level problem with the WKWebView, since none of the WKNavigationDelegate methods fire in these cases.
> 
> Since the native code doesn't tell us when the location changes this way, the semi-hacky solution is to inject Javascript into the user page. This Javascript intercepts calls to the window.history API and sends an event to the native code when this happens. The native code then fires an onLoadingFinish event, just like Android.
> 
> When I first implemented this, I didn't realize that the guide actually included a similar solution as the recommended workaround. My initial solution, #641, didn't quite cover all the cases, but I was able to solve the edge cases by stealing some ideas from the official workaround. Specifically, hooking the popstate event instead of shimming the back, forward, and go methods is not only simpler, but it also catches WebView.goBack() calls and distinguishes between true navigation events and same-page hash changes.
> 
> Since this solution is native, it doesn't interfere with the postMessage / onMessage mechanism in the same way the official workaround does.
> 

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
Followed instructions from original PR.
![historydemo](https://user-images.githubusercontent.com/8675043/70856476-b6411b00-1e92-11ea-9943-655c4b9bcd57.gif)


> I created a fresh react-native init project, and replaced render with the following code:
> 
>   render() {
>     return (
>       <WebView
>         style={{ flex: 1, alignSelf: "stretch" }}
>         source={{ uri: "https://www.swansontec.com/temp/history/a.html" }}
>         onNavigationStateChange={event =>
>           console.log(event.url, event.canGoBack, event.navigationType)
>         }
>       />
>     );
>   }
> }
> Then, I ran the debugger while performing the same sequence of events on various platforms:
> 
> push a#n
> push a#n
> back
> back
> Using the unmodified react-native-webview on iOS generated no output. After the changes, iOS generates the following logs:
> 
> https://www.swansontec.com/temp/history/a.html#1 true other
> https://www.swansontec.com/temp/history/a.html#2 true other
> https://www.swansontec.com/temp/history/a.html#1 true backforward
> https://www.swansontec.com/temp/history/a.html false backforward
> And Android generates:
> 
> https://www.swansontec.com/temp/history/a.html#1 true undefined
> https://www.swansontec.com/temp/history/a.html#2 true undefined
> https://www.swansontec.com/temp/history/a.html#1 true undefined
> https://www.swansontec.com/temp/history/a.html false undefined
> So now iOS is generating the same events! The test site includes a lot of other functionality besides this simple test case, and this fix causes iOS to work about the same as Android in most cases.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅ (no change)     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
