### PR TITLE
fix:iOS WKWebView RetainCycle

### DIFF
--- a/ios/RNCWebView.h
+++ b/ios/RNCWebView.h
@@ -19,6 +19,11 @@
 
 @end
 
+@interface RNCWeakScriptMessageDelegate : NSObject<WKScriptMessageHandler>
+@property (nonatomic, weak) id<WKScriptMessageHandler> scriptDelegate;
+- (instancetype)initWithDelegate:(id<WKScriptMessageHandler>)scriptDelegate;
+@end
+
 @interface RNCWebView : RCTView
 
 @property (nonatomic, weak) id<RNCWebViewDelegate> _Nullable delegate;

--- a/ios/RNCWebView.m
+++ b/ios/RNCWebView.m
@@ -162,7 +162,8 @@ static NSDictionary* customCertificatesForHost;
     wkWebViewConfig.userContentController = [WKUserContentController new];
 
     // Shim the HTML5 history API:
-    [wkWebViewConfig.userContentController addScriptMessageHandler:self name:HistoryShimName];
+    [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
+                                                              name:HistoryShimName];
     NSString *source = [NSString stringWithFormat:
       @"(function(history) {\n"
       "  function notify(type) {\n"
@@ -187,7 +188,8 @@ static NSDictionary* customCertificatesForHost;
     [wkWebViewConfig.userContentController addUserScript:script];
 
     if (_messagingEnabled) {
-      [wkWebViewConfig.userContentController addScriptMessageHandler:self name:MessageHandlerName];
+      [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
+                                                                name:MessageHandlerName];
 
       NSString *source = [NSString stringWithFormat:
         @"window.%@ = {"
@@ -1077,3 +1079,20 @@ static NSDictionary* customCertificatesForHost;
 }
 
 @end
+
+@implementation RNCWeakScriptMessageDelegate
+
+- (instancetype)initWithDelegate:(id<WKScriptMessageHandler>)scriptDelegate {
+    self = [super init];
+    if (self) {
+        _scriptDelegate = scriptDelegate;
+    }
+    return self;
+}
+
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
+    [self.scriptDelegate userContentController:userContentController didReceiveScriptMessage:message];
+}
+
+@end
+


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Fix iOS WKWebView retain cycle

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
--> 

When close the webview, dealloc function does not execute, there have a retain cycle in RNCWebView.m file

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
NO
### What are the steps to reproduce (after prerequisites)?
Hit berakpoint in dealloc function，after the webview close，this function is not excute
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
