### PR TITLE
Extract wkWebViewConfig setup into setUpWkWebViewConfig function

### DIFF
--- a/ios/RNCWebView.m
+++ b/ios/RNCWebView.m
@@ -134,157 +134,163 @@ static NSDictionary* customCertificatesForHost;
   return nil;
 }
 
+- (WKWebViewConfiguration *)setUpWkWebViewConfig
+{
+  WKWebViewConfiguration *wkWebViewConfig = [WKWebViewConfiguration new];
+  WKPreferences *prefs = [[WKPreferences alloc]init];
+  BOOL _prefsUsed = NO;
+  if (!_javaScriptEnabled) {
+    prefs.javaScriptEnabled = NO;
+    _prefsUsed = YES;
+  }
+  if (_allowFileAccessFromFileURLs) {
+    [prefs setValue:@TRUE forKey:@"allowFileAccessFromFileURLs"];
+    _prefsUsed = YES;
+  }
+  if (_prefsUsed) {
+    wkWebViewConfig.preferences = prefs;
+  }
+  if (_incognito) {
+    wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
+  } else if (_cacheEnabled) {
+    wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore defaultDataStore];
+  }
+  if(self.useSharedProcessPool) {
+    wkWebViewConfig.processPool = [[RNCWKProcessPoolManager sharedManager] sharedProcessPool];
+  }
+  wkWebViewConfig.userContentController = [WKUserContentController new];
+
+  // Shim the HTML5 history API:
+  [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
+                                                            name:HistoryShimName];
+  NSString *source = [NSString stringWithFormat:
+    @"(function(history) {\n"
+    "  function notify(type) {\n"
+    "    setTimeout(function() {\n"
+    "      window.webkit.messageHandlers.%@.postMessage(type)\n"
+    "    }, 0)\n"
+    "  }\n"
+    "  function shim(f) {\n"
+    "    return function pushState() {\n"
+    "      notify('other')\n"
+    "      return f.apply(history, arguments)\n"
+    "    }\n"
+    "  }\n"
+    "  history.pushState = shim(history.pushState)\n"
+    "  history.replaceState = shim(history.replaceState)\n"
+    "  window.addEventListener('popstate', function() {\n"
+    "    notify('backforward')\n"
+    "  })\n"
+    "})(window.history)\n", HistoryShimName
+  ];
+  WKUserScript *script = [[WKUserScript alloc] initWithSource:source injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
+  [wkWebViewConfig.userContentController addUserScript:script];
+
+  if (_messagingEnabled) {
+    [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
+                                                              name:MessageHandlerName];
+
+    NSString *source = [NSString stringWithFormat:
+      @"window.%@ = {"
+       "  postMessage: function (data) {"
+       "    window.webkit.messageHandlers.%@.postMessage(String(data));"
+       "  }"
+       "};", MessageHandlerName, MessageHandlerName
+    ];
+
+    WKUserScript *script = [[WKUserScript alloc] initWithSource:source injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
+    [wkWebViewConfig.userContentController addUserScript:script];
+      
+    if (_injectedJavaScriptBeforeContentLoaded) {
+      // If user has provided an injectedJavascript prop, execute it at the start of the document
+      WKUserScript *injectedScript = [[WKUserScript alloc] initWithSource:_injectedJavaScriptBeforeContentLoaded injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
+      [wkWebViewConfig.userContentController addUserScript:injectedScript];
+    }
+  }
+
+  wkWebViewConfig.allowsInlineMediaPlayback = _allowsInlineMediaPlayback;
+#if WEBKIT_IOS_10_APIS_AVAILABLE
+  wkWebViewConfig.mediaTypesRequiringUserActionForPlayback = _mediaPlaybackRequiresUserAction
+    ? WKAudiovisualMediaTypeAll
+    : WKAudiovisualMediaTypeNone;
+  wkWebViewConfig.dataDetectorTypes = _dataDetectorTypes;
+#else
+  wkWebViewConfig.mediaPlaybackRequiresUserAction = _mediaPlaybackRequiresUserAction;
+#endif
+
+  if (_applicationNameForUserAgent) {
+      wkWebViewConfig.applicationNameForUserAgent = [NSString stringWithFormat:@"%@ %@", wkWebViewConfig.applicationNameForUserAgent, _applicationNameForUserAgent];
+  }
+
+  if(_sharedCookiesEnabled) {
+    // More info to sending cookies with WKWebView
+    // https://stackoverflow.com/questions/26573137/can-i-set-the-cookies-to-be-used-by-a-wkwebview/26577303#26577303
+    if (@available(iOS 11.0, *)) {
+      // Set Cookies in iOS 11 and above, initialize websiteDataStore before setting cookies
+      // See also https://forums.developer.apple.com/thread/97194
+      // check if websiteDataStore has not been initialized before
+      if(!_incognito && !_cacheEnabled) {
+        wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
+      }
+      for (NSHTTPCookie *cookie in [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies]) {
+        [wkWebViewConfig.websiteDataStore.httpCookieStore setCookie:cookie completionHandler:nil];
+      }
+    } else {
+      NSMutableString *script = [NSMutableString string];
+
+      // Clear all existing cookies in a direct called function. This ensures that no
+      // javascript error will break the web content javascript.
+      // We keep this code here, if someone requires that Cookies are also removed within the
+      // the WebView and want to extends the current sharedCookiesEnabled option with an
+      // additional property.
+      // Generates JS: document.cookie = "key=; Expires=Thu, 01 Jan 1970 00:00:01 GMT;"
+      // for each cookie which is already available in the WebView context.
+      /*
+      [script appendString:@"(function () {\n"];
+      [script appendString:@"  var cookies = document.cookie.split('; ');\n"];
+      [script appendString:@"  for (var i = 0; i < cookies.length; i++) {\n"];
+      [script appendString:@"    if (cookies[i].indexOf('=') !== -1) {\n"];
+      [script appendString:@"      document.cookie = cookies[i].split('=')[0] + '=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';\n"];
+      [script appendString:@"    }\n"];
+      [script appendString:@"  }\n"];
+      [script appendString:@"})();\n\n"];
+      */
+
+      // Set cookies in a direct called function. This ensures that no
+      // javascript error will break the web content javascript.
+        // Generates JS: document.cookie = "key=value; Path=/; Expires=Thu, 01 Jan 20xx 00:00:01 GMT;"
+      // for each cookie which is available in the application context.
+      [script appendString:@"(function () {\n"];
+      for (NSHTTPCookie *cookie in [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies]) {
+        [script appendFormat:@"document.cookie = %@ + '=' + %@",
+          RCTJSONStringify(cookie.name, NULL),
+          RCTJSONStringify(cookie.value, NULL)];
+        if (cookie.path) {
+          [script appendFormat:@" + '; Path=' + %@", RCTJSONStringify(cookie.path, NULL)];
+        }
+        if (cookie.expiresDate) {
+          [script appendFormat:@" + '; Expires=' + new Date(%f).toUTCString()",
+            cookie.expiresDate.timeIntervalSince1970 * 1000
+          ];
+        }
+        [script appendString:@";\n"];
+      }
+      [script appendString:@"})();\n"];
+
+      WKUserScript* cookieInScript = [[WKUserScript alloc] initWithSource:script
+                                                            injectionTime:WKUserScriptInjectionTimeAtDocumentStart
+                                                         forMainFrameOnly:YES];
+      [wkWebViewConfig.userContentController addUserScript:cookieInScript];
+    }
+  }
+  
+  return wkWebViewConfig;
+}
+
 - (void)didMoveToWindow
 {
   if (self.window != nil && _webView == nil) {
-    WKWebViewConfiguration *wkWebViewConfig = [WKWebViewConfiguration new];
-    WKPreferences *prefs = [[WKPreferences alloc]init];
-    BOOL _prefsUsed = NO;
-    if (!_javaScriptEnabled) {
-      prefs.javaScriptEnabled = NO;
-      _prefsUsed = YES;
-    }
-    if (_allowFileAccessFromFileURLs) {
-      [prefs setValue:@TRUE forKey:@"allowFileAccessFromFileURLs"];
-      _prefsUsed = YES;
-    }
-    if (_prefsUsed) {
-      wkWebViewConfig.preferences = prefs;
-    }
-    if (_incognito) {
-      wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
-    } else if (_cacheEnabled) {
-      wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore defaultDataStore];
-    }
-    if(self.useSharedProcessPool) {
-      wkWebViewConfig.processPool = [[RNCWKProcessPoolManager sharedManager] sharedProcessPool];
-    }
-    wkWebViewConfig.userContentController = [WKUserContentController new];
-
-    // Shim the HTML5 history API:
-    [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
-                                                              name:HistoryShimName];
-    NSString *source = [NSString stringWithFormat:
-      @"(function(history) {\n"
-      "  function notify(type) {\n"
-      "    setTimeout(function() {\n"
-      "      window.webkit.messageHandlers.%@.postMessage(type)\n"
-      "    }, 0)\n"
-      "  }\n"
-      "  function shim(f) {\n"
-      "    return function pushState() {\n"
-      "      notify('other')\n"
-      "      return f.apply(history, arguments)\n"
-      "    }\n"
-      "  }\n"
-      "  history.pushState = shim(history.pushState)\n"
-      "  history.replaceState = shim(history.replaceState)\n"
-      "  window.addEventListener('popstate', function() {\n"
-      "    notify('backforward')\n"
-      "  })\n"
-      "})(window.history)\n", HistoryShimName
-    ];
-    WKUserScript *script = [[WKUserScript alloc] initWithSource:source injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
-    [wkWebViewConfig.userContentController addUserScript:script];
-
-    if (_messagingEnabled) {
-      [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
-                                                                name:MessageHandlerName];
-
-      NSString *source = [NSString stringWithFormat:
-        @"window.%@ = {"
-         "  postMessage: function (data) {"
-         "    window.webkit.messageHandlers.%@.postMessage(String(data));"
-         "  }"
-         "};", MessageHandlerName, MessageHandlerName
-      ];
-
-      WKUserScript *script = [[WKUserScript alloc] initWithSource:source injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
-      [wkWebViewConfig.userContentController addUserScript:script];
-        
-      if (_injectedJavaScriptBeforeContentLoaded) {
-        // If user has provided an injectedJavascript prop, execute it at the start of the document
-        WKUserScript *injectedScript = [[WKUserScript alloc] initWithSource:_injectedJavaScriptBeforeContentLoaded injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
-        [wkWebViewConfig.userContentController addUserScript:injectedScript];
-      }
-    }
-
-    wkWebViewConfig.allowsInlineMediaPlayback = _allowsInlineMediaPlayback;
-#if WEBKIT_IOS_10_APIS_AVAILABLE
-    wkWebViewConfig.mediaTypesRequiringUserActionForPlayback = _mediaPlaybackRequiresUserAction
-      ? WKAudiovisualMediaTypeAll
-      : WKAudiovisualMediaTypeNone;
-    wkWebViewConfig.dataDetectorTypes = _dataDetectorTypes;
-#else
-    wkWebViewConfig.mediaPlaybackRequiresUserAction = _mediaPlaybackRequiresUserAction;
-#endif
-
-    if (_applicationNameForUserAgent) {
-        wkWebViewConfig.applicationNameForUserAgent = [NSString stringWithFormat:@"%@ %@", wkWebViewConfig.applicationNameForUserAgent, _applicationNameForUserAgent];
-    }
-
-    if(_sharedCookiesEnabled) {
-      // More info to sending cookies with WKWebView
-      // https://stackoverflow.com/questions/26573137/can-i-set-the-cookies-to-be-used-by-a-wkwebview/26577303#26577303
-      if (@available(iOS 11.0, *)) {
-        // Set Cookies in iOS 11 and above, initialize websiteDataStore before setting cookies
-        // See also https://forums.developer.apple.com/thread/97194
-        // check if websiteDataStore has not been initialized before
-        if(!_incognito && !_cacheEnabled) {
-          wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
-        }
-        for (NSHTTPCookie *cookie in [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies]) {
-          [wkWebViewConfig.websiteDataStore.httpCookieStore setCookie:cookie completionHandler:nil];
-        }
-      } else {
-        NSMutableString *script = [NSMutableString string];
-
-        // Clear all existing cookies in a direct called function. This ensures that no
-        // javascript error will break the web content javascript.
-        // We keep this code here, if someone requires that Cookies are also removed within the
-        // the WebView and want to extends the current sharedCookiesEnabled option with an
-        // additional property.
-        // Generates JS: document.cookie = "key=; Expires=Thu, 01 Jan 1970 00:00:01 GMT;"
-        // for each cookie which is already available in the WebView context.
-        /*
-        [script appendString:@"(function () {\n"];
-        [script appendString:@"  var cookies = document.cookie.split('; ');\n"];
-        [script appendString:@"  for (var i = 0; i < cookies.length; i++) {\n"];
-        [script appendString:@"    if (cookies[i].indexOf('=') !== -1) {\n"];
-        [script appendString:@"      document.cookie = cookies[i].split('=')[0] + '=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';\n"];
-        [script appendString:@"    }\n"];
-        [script appendString:@"  }\n"];
-        [script appendString:@"})();\n\n"];
-        */
-
-        // Set cookies in a direct called function. This ensures that no
-        // javascript error will break the web content javascript.
-          // Generates JS: document.cookie = "key=value; Path=/; Expires=Thu, 01 Jan 20xx 00:00:01 GMT;"
-        // for each cookie which is available in the application context.
-        [script appendString:@"(function () {\n"];
-        for (NSHTTPCookie *cookie in [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies]) {
-          [script appendFormat:@"document.cookie = %@ + '=' + %@",
-            RCTJSONStringify(cookie.name, NULL),
-            RCTJSONStringify(cookie.value, NULL)];
-          if (cookie.path) {
-            [script appendFormat:@" + '; Path=' + %@", RCTJSONStringify(cookie.path, NULL)];
-          }
-          if (cookie.expiresDate) {
-            [script appendFormat:@" + '; Expires=' + new Date(%f).toUTCString()",
-              cookie.expiresDate.timeIntervalSince1970 * 1000
-            ];
-          }
-          [script appendString:@";\n"];
-        }
-        [script appendString:@"})();\n"];
-
-        WKUserScript* cookieInScript = [[WKUserScript alloc] initWithSource:script
-                                                              injectionTime:WKUserScriptInjectionTimeAtDocumentStart
-                                                           forMainFrameOnly:YES];
-        [wkWebViewConfig.userContentController addUserScript:cookieInScript];
-      }
-    }
-
+    WKWebViewConfiguration *wkWebViewConfig = [self setUpWkWebViewConfig];
     _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
     [self setBackgroundColor: _savedBackgroundColor];
     _webView.scrollView.delegate = self;


### PR DESCRIPTION
# Summary

I intend to implement updatable user scripts (i.e. user scripts such as injected JS would be updated upon props change), and this will involve removing and re-adding all scripts on the `wkWebViewConfiguration`.

A necessary first step is to extract all the config setup from `didMoveToWindow()` into a separate function. This is beneficial anyway as `didMoveToWindow()` is enormous and hard to analyse at the moment due to all this logic.

This purely a function extraction and will not impact the library.

## Test Plan

None; minor change.

### What's required for testing (prerequisites)?

None; minor change.

### What are the steps to reproduce (after prerequisites)?

None; minor change.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
