### PR TITLE
Force add extra headers - referer

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -609,7 +609,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         if (args == null) {
           throw new RuntimeException("Arguments for loading an url are null!");
         }
-        root.loadUrl(args.getString(0));
+        HashMap<String, String> headerMap = new HashMap<>();
+        headerMap.put("referer", root.getUrl());
+        
+        root.loadUrl(args.getString(0), headerMap);
         break;
       case COMMAND_FOCUS:
         root.requestFocus();


### PR DESCRIPTION
# Summary
Android does not include referer into Header if we handle `onShouldStartLoadWithRequest`.
 
* What issues does the pull request solve? 
https://github.com/react-native-community/react-native-webview/issues/460
* How did you implement the solution?
Force add Referer as previous url for every calling `loadUrl` 
* What areas of the library does it impact?


## Test Plan
![image](https://user-images.githubusercontent.com/4475472/72125952-ff569300-339c-11ea-8095-8c16b6010b39.png)

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist
- [x] I have tested this on a device and a simulator
