### PR TITLE
fix(types): Add missing applicationNameForUserAgent type in WebViewSharedProps

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -736,4 +736,9 @@ export interface WebViewSharedProps extends ViewProps {
    * Should caching be enabled. Default is true.
    */
   cacheEnabled?: boolean;
+
+  /**
+   * Append to the existing user-agent. Overriden if `userAgent` is set.
+   */
+  applicationNameForUserAgent?: string;
 }


### PR DESCRIPTION
# Summary

In Typescript, using `applicationNameForUserAgent` in `<WebView>` would throw a type error
```
  Property 'applicationNameForUserAgent' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<WebView> & Readonly<WebViewProps> & Readonly<{ children?: ReactNode; }>'.
```
This is due to https://github.com/react-native-community/react-native-webview/pull/707 moved the type definition from `WebViewSharedProps` to `CommonNativeWebViewProps`. We should probably define the type in both props.

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
