### PR TITLE
Add config to ignore Ssl errors on Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -11,6 +11,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.Manifest;
 import android.net.Uri;
+import android.net.http.SslError;
 import android.os.Build;
 import android.os.Environment;
 import androidx.annotation.RequiresApi;
@@ -27,6 +28,7 @@ import android.webkit.DownloadListener;
 import android.webkit.GeolocationPermissions;
 import android.webkit.JavascriptInterface;
 import android.webkit.PermissionRequest;
+import android.webkit.SslErrorHandler;
 import android.webkit.URLUtil;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
@@ -135,6 +137,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   protected boolean mAllowsFullscreenVideo = false;
   protected @Nullable String mUserAgent = null;
   protected @Nullable String mUserAgentWithApplicationName = null;
+  public static boolean mignoreSslErrors = false;
 
   public RNCWebViewManager() {
     mWebViewConfig = new WebViewConfig() {
@@ -529,6 +532,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     ((RNCWebView) view).setHasScrollEvent(hasScrollEvent);
   }
 
+  @ReactProp(name = "ignoreSslErrors")
+  public void setIgnoreSslErrors(WebView view, @Nullable Boolean ignoreSslErrors) {
+    mignoreSslErrors = ignoreSslErrors != null && ignoreSslErrors;
+  }
+
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches
@@ -714,6 +722,15 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     protected boolean mLastLoadFailed = false;
     protected @Nullable
     ReadableArray mUrlPrefixesForDefaultIntent;
+
+    @Override
+    public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+      if (mignoreSslErrors) {
+        handler.proceed();
+      }
+
+      super.onReceivedSslError(view, handler, error);
+    }
 
     @Override
     public void onPageFinished(WebView webView, String url) {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -725,7 +725,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-      if (ReactBuildConfig.DEBUG && mignoreSslErrors) {
+      if (BuildConfig.DEBUG && mignoreSslErrors) {
         handler.proceed();
       }
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -725,7 +725,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-      if (mignoreSslErrors) {
+      if (ReactBuildConfig.DEBUG && mignoreSslErrors) {
         handler.proceed();
       }
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1095,6 +1095,8 @@ Example:
 
 Ignore Ssl errors encountered in the webview. 
 
+Works only in debug mode.
+
 | Type    | Required | Platform |
 | ------- | -------- | -------- |
 | boolean | No       | Android      |

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1091,6 +1091,14 @@ Example:
 
 `<WebView textZoom={100} />`
 
+### `ignoreSslErrors`
+
+Ignore Ssl errors encountered in the webview. 
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | Android      |
+
 ## Methods
 
 ### `extraNativeComponentConfig()`

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -54,6 +54,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     cacheEnabled: true,
     androidHardwareAccelerationDisabled: false,
     originWhitelist: defaultOriginWhitelist,
+    ignoreSslErrors: false,
   };
 
   static isFileUploadSupported = async () => {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -590,6 +590,11 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * Sets ability to open fullscreen videos on Android devices.
    */
   allowsFullscreenVideo?: boolean;
+
+  /**
+   * Ignore Ssl errors.
+   */
+  ignoreSslErrors?: boolean;
 }
 
 export interface WebViewSharedProps extends ViewProps {


### PR DESCRIPTION
# Summary

Added `ignoreSslErrors` to allow ssl errors in debug mode.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

### What's required for testing (prerequisites)?

Open a website with a self signed certificate (with or without CA). 

Error or blank page is displayed.

adb logcat shows `java.security.cert.CertPathValidatorException: Trust anchor for certification path not found.`.

### What are the steps to reproduce (after prerequisites)?

Open a website with a self signed certificate (with or without CA).

Website should be displayed properly.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
