### PR TITLE
feat(iOS): integrate API for disabling server trust evaluation

### DIFF
--- a/docs/Custom-iOS.md
+++ b/docs/Custom-iOS.md
@@ -148,7 +148,7 @@ If you need to connect to a server which has a self signed certificate, or want 
 
 
 ```objc
--(void)installCerts {
+- (void)installCerts {
 
   // Get the bundle where the certificates in DER format are present.
   NSBundle *bundle = [NSBundle mainBundle];
@@ -158,18 +158,26 @@ If you need to connect to a server which has a self signed certificate, or want 
   NSData *rootCertData = [NSData dataWithContentsOfFile:[bundle pathForResource:@"example_ca" ofType:@"der"]];
 
   SecCertificateRef certificate = SecCertificateCreateWithData(NULL, (CFDataRef) rootCertData);
-   
-  OSStatus err = SecItemAdd((CFDictionaryRef) [NSDictionary dictionaryWithObjectsAndKeys:(id) kSecClassCertificate, kSecClass, certificate, kSecValueRef, nil], NULL);
   
   [certMap setObject:(__bridge id _Nonnull)(certificate) forKey:@"example.com"];
 
   [RNCWebView setCustomCertificatesForHost:certMap];
+  
+  CFRelease(certificate);
 }
 
 ```
 
-Multiple hosts can be added to the directionary, and only one certificate for a host is allowed. The verification will succeed if any of the certificates in the chain of the request matches the one defined for the request's host.
+Multiple hosts can be added to the dictionary and only one certificate for a host is allowed. The verification will succeed if any of the certificates in the chain of the request matches the one defined for the request's host.
 
+Additionally, you can disable server trust evaluation invoking the following method:
+
+```objc
+[RNCWebView disableServerTrustEvaluation];
+```
+
+This means that the verification will succeed independently from the certificate sent by the server.
+As a rule of thumb, don't use the above API in production but just for testing purposes.
 
 ## JavaScript Interface
 

--- a/ios/RNCWebView.h
+++ b/ios/RNCWebView.h
@@ -61,6 +61,7 @@
 
 + (void)setClientAuthenticationCredential:(nullable NSURLCredential*)credential;
 + (void)setCustomCertificatesForHost:(nullable NSDictionary *)certificates;
++ (void)disableServerTrustEvaluation;
 - (void)postMessage:(NSString *_Nullable)message;
 - (void)injectJavaScript:(NSString *_Nullable)script;
 - (void)goForward;


### PR DESCRIPTION
* Integrate API for disabling server trust evaluation
* Remove unnecessary sender value
* Format code
* Fix Custom-iOS.md

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

The PR aims to solve a scenario where the web view needs to load html pages that have self-signed or invalid certificates through the `file://` protocol. Since `webView.URL.host` returns `nil` with local files, the validation always fails. 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Create an HTML page that performs some network requests through a self-signed or invalid certificate.
Embed this HTML page locally and load it into the web view.
In your `AppDelegate` invoke the new API as follows:

```
[RNCWebView disableServerTrustEvaluation];
```

### What's required for testing (prerequisites)?

* Having a local HTML page that performs some network requests from a server that has a self-signed or invalid certificate.

### What are the steps to reproduce (after prerequisites)?

* Verify that the HTML page performs the network request correctly.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
