### PR TITLE
iOS injectedJavaScriptBeforeContentLoaded fix when messaging disabled

### DIFF
--- a/ios/RNCWebView.m
+++ b/ios/RNCWebView.m
@@ -200,12 +200,12 @@ static NSDictionary* customCertificatesForHost;
 
     WKUserScript *script = [[WKUserScript alloc] initWithSource:source injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
     [wkWebViewConfig.userContentController addUserScript:script];
-      
-    if (_injectedJavaScriptBeforeContentLoaded) {
-      // If user has provided an injectedJavascript prop, execute it at the start of the document
-      WKUserScript *injectedScript = [[WKUserScript alloc] initWithSource:_injectedJavaScriptBeforeContentLoaded injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
-      [wkWebViewConfig.userContentController addUserScript:injectedScript];
-    }
+  }
+
+  if (_injectedJavaScriptBeforeContentLoaded) {
+    // If user has provided an injectedJavascript prop, execute it at the start of the document
+    WKUserScript *injectedScript = [[WKUserScript alloc] initWithSource:_injectedJavaScriptBeforeContentLoaded injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
+    [wkWebViewConfig.userContentController addUserScript:injectedScript];
   }
 
   wkWebViewConfig.allowsInlineMediaPlayback = _allowsInlineMediaPlayback;


### PR DESCRIPTION
# Summary

I previously implemented injectedJavaScriptBeforeContentLoaded here:
https://github.com/react-native-community/react-native-webview/pull/1038

This change makes it so that this prop/API works even if the webview has messaging disabled.

I don't remember this being a conscious choice to disable injectedJavaScriptBeforeContentLoaded when messaging was not enabled since the two props do not depend on one another, so probably was an oversight on my end.

Just caught this because I am now running the webview without messaging enabled

## Test Plan

Run the same test described here:
https://github.com/react-native-community/react-native-webview/pull/1038

and do not provide any onMessage prop

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [N/A] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
