### PR TITLE
Revert "fix(android): redirected URL cannot be loaded normally."

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -748,7 +748,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         new TopShouldStartLoadWithRequestEvent(
           view.getId(),
           createWebViewEvent(view, url)));
-      return super.shouldOverrideUrlLoading(view,url);
+      return true;
     }
 
 


### PR DESCRIPTION
Reverts react-native-community/react-native-webview#991.

This is causing a bug where we can never prevent a page from loading by returning false in `onShouldStartLoadWithRequest`.