### PR TITLE
WIP: fix(android): add Referer header for url redirect load

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -937,6 +937,10 @@ static NSDictionary* customCertificatesForHost;
       @"mainDocumentURL": (request.mainDocumentURL).absoluteString,
       @"navigationType": navigationTypes[@(navigationType)]
     }];
+    NSString *referer = [request valueForHTTPHeaderField:@"referer"];
+    if (referer) {
+      [event setObject:referer forKey:@"referer"];
+    }
     if (![self.delegate webView:self
       shouldStartLoadForRequest:event
                    withCallback:_onShouldStartLoadWithRequest]) {

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -647,6 +647,7 @@ canGoForward
 lockIdentifier
 mainDocumentURL (iOS only)
 navigationType
+referer
 ```
 
 ---

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -111,6 +111,7 @@ export interface WebViewNavigation extends WebViewNativeEvent {
     | 'formresubmit'
     | 'other';
   mainDocumentURL?: string;
+  referer?: string;
 }
 
 export interface FileDownload {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
For redirected url loading, current behehavior is we always return `true` to prevent it being loaded in `shouldOverrideUrlLoading`, with `TopShouldStartLoadWithRequestEvent` being sent to RN and then call `webview.loadUrl()` if such redirect loading was approved on RN.
However, the `Referer` header would be different between `webview.loadUrl` and return `false` in `shouldOverrideUrlLoading`. It might cause redirect issues ( #1073 ) if `Referer` matters at the server side.  
The code change inside this PR is to save a `refererUrl` when sending `TopShouldStartLoadWithRequestEvent` to RN and use it to construct a request with `Referer` header later.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?
test loading `https://s.click.taobao.com/fj2tptv` (url from #1073 ) 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
