### PR TITLE
fix(Android): Don't show camera options for a file upload when they can not be used

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -32,6 +32,7 @@ import com.facebook.react.modules.core.PermissionListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import static android.app.Activity.RESULT_OK;
 
@@ -180,11 +181,13 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     filePathCallback = callback;
 
     ArrayList<Parcelable> extraIntents = new ArrayList<>();
-    if (acceptsImages(acceptTypes)) {
-      extraIntents.add(getPhotoIntent());
-    }
-    if (acceptsVideo(acceptTypes)) {
-      extraIntents.add(getVideoIntent());
+    if (! needsCameraPermission()) {
+      if (acceptsImages(acceptTypes)) {
+        extraIntents.add(getPhotoIntent());
+      }
+      if (acceptsVideo(acceptTypes)) {
+        extraIntents.add(getVideoIntent());
+      }
     }
 
     Intent fileSelectionIntent = getFileChooserIntent(acceptTypes, allowMultiple);
@@ -231,6 +234,23 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     }
 
     return result;
+  }
+
+  protected boolean needsCameraPermission() {
+    boolean needed = false;
+
+    PackageManager packageManager = getCurrentActivity().getPackageManager();
+    try {
+      String[] requestedPermissions = packageManager.getPackageInfo(getReactApplicationContext().getPackageName(), PackageManager.GET_PERMISSIONS).requestedPermissions;
+      if (Arrays.asList(requestedPermissions).contains(Manifest.permission.CAMERA)
+        && ContextCompat.checkSelfPermission(getCurrentActivity(), Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+        needed = true;
+      }
+    } catch (PackageManager.NameNotFoundException e) {
+      needed = true;
+    }
+
+    return needed;
   }
 
   private Intent getPhotoIntent() {

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -191,6 +191,12 @@ Add permission in AndroidManifest.xml:
 </manifest>
 ```
 
+###### Camera option availability in uploading for Android
+
+If the file input indicates that images or video is desired with [`accept`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept), then the WebView will attempt to provide options to the user to use their camera to take a picture or video.
+
+Normally, apps that do not have permission to use the camera can prompt the user to use an external app so that the requesting app has no need for permission. However, Android has made a special exception for this around the camera to reduce confusion for users. If an app *can* request the camera permission because it has been declared, and the user has not granted the permission, it may not fire an intent that would use the camera (`MediaStore.ACTION_IMAGE_CAPTURE` or `MediaStore.ACTION_VIDEO_CAPTURE`). In this scenario, it is up to the developer to request camera permission before a file upload directly using the camera is necessary.
+
 ##### Check for File Upload support, with `static isFileUploadSupported()`
 
 File Upload using `<input type="file" />` is not supported for Android 4.4 KitKat (see [details](https://github.com/delight-im/Android-AdvancedWebView/issues/4#issuecomment-70372146)):
@@ -301,7 +307,7 @@ _Under the hood_
 
 #### The `injectedJavaScriptBeforeContentLoaded` prop
 
-This is a script that runs **before** the web page loads for the first time. It only runs once, even if the page is reloaded or navigated away. This is useful if you want to inject anything into the window, localstorage, or document prior to the web code executing. 
+This is a script that runs **before** the web page loads for the first time. It only runs once, even if the page is reloaded or navigated away. This is useful if you want to inject anything into the window, localstorage, or document prior to the web code executing.
 
 ```jsx
 import React, { Component } from 'react';
@@ -329,7 +335,7 @@ export default class App extends Component {
 }
 ```
 
-This runs the JavaScript in the `runFirst` string before the page is loaded. In this case, the value of `window.isNativeApp` will be set to true before the web code executes. 
+This runs the JavaScript in the `runFirst` string before the page is loaded. In this case, the value of `window.isNativeApp` will be set to true before the web code executes.
 
 #### The `injectJavaScript` method
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -7,11 +7,13 @@ import {
   View,
   Keyboard,
   Button,
+  Platform,
 } from 'react-native';
 
 import Alerts from './examples/Alerts';
 import Scrolling from './examples/Scrolling';
 import Background from './examples/Background';
+import Uploads from './examples/Uploads';
 
 const TESTS = {
   Alerts: {
@@ -36,6 +38,14 @@ const TESTS = {
     description: 'Background color test',
     render() {
       return <Background />;
+    },
+  },
+  Uploads: {
+    title: 'Uploads',
+    testId: 'uploads',
+    description: 'Upload test',
+    render() {
+      return <Uploads />;
     },
   },
 };
@@ -91,6 +101,11 @@ export default class App extends Component<Props, State> {
             title="Background"
             onPress={() => this._changeTest('Background')}
           />
+          {Platform.OS === 'android' && <Button
+            testID="testType_uploads"
+            title="Uploads"
+            onPress={() => this._changeTest('Uploads')}
+          />}
         </View>
 
         {restarting ? null : (

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   package="com.example">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
       android:name=".MainApplication"

--- a/example/examples/Uploads.tsx
+++ b/example/examples/Uploads.tsx
@@ -1,0 +1,69 @@
+import React, {Component} from 'react';
+import {Button, Linking, Text, View} from 'react-native';
+
+import WebView from 'react-native-webview';
+
+const HTML = `
+<!DOCTYPE html>\n
+<html>
+  <head>
+    <title>Uploads</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=320, user-scalable=no">
+    <style type="text/css">
+      body {
+        margin: 0;
+        padding: 0;
+        font: 62.5% arial, sans-serif;
+        background: #ccc;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      <label for="images-only">Images only file upload</label>
+      <input name="images-only" type="file" accept="image/*">
+    </p>
+    <p>
+      <label for="video-only">Video only file upload</label>
+      <input name="video-only" type="file" accept="video/*">
+    </p>
+    <p>
+      <label for="any-file">Any file upload</label>
+      <input name="any-file" type="file">
+    </p>
+  </body>
+</html>
+`;
+
+type Props = {};
+type State = {};
+
+export default class Uploads extends Component<Props, State> {
+  state = {};
+
+  render() {
+    return (
+      <View>
+        <View style={{ height: 120 }}>
+          <WebView
+            source={{html: HTML}}
+            automaticallyAdjustContentInsets={false}
+          />
+        </View>
+        <Text>
+            Android limitation: If the file input should show camera options for the user,
+            and the app has the ability to request the camera permission, then the user must
+            grant permission first in order to see the options. Since this example app does
+            have the permission declared, you must allow it in settings to be able to see
+            camera options. If your app does not have the camera permission declared, then
+            there is no restriction to showing the camera options.
+        </Text>
+        <Button
+          title="Open settings"
+          onPress={() => Linking.openSettings()}
+        />
+      </View>
+    );
+  }
+}


### PR DESCRIPTION
# Summary

Don't show camera options for a file upload that would result in nothing happening for the user.

On Android, if the application declares the camera permission, then even intents that use the camera require permission to be granted. This is a problem for apps that combine an in-app camera with a WebView that has file uploading and the user has not given permission for the camera.

Note, this will not request permission for camera. This will simply prevent showing the camera options that would be a no-op action for users. It does this by checking if the camera permission is declared, and if so, checks that the user has granted permission.

[More information on this camera permission/intent issue.](https://blog.egorand.me/taking-photos-not-so-simply-how-i-got-bitten-by-action_image_capture/)

## Test Plan

We have had this patch in our app for some time. I also tested it by modifying the example app.  First I modified the WebView to go to a page that has file inputs that would trigger the camera options (an example being https://addpipe.com/html-media-capture-demo/). I verified the camera options are present.

Then I declared the camera permission by adding this to the `AndroidManifest.xml`:

```xml
<uses-permission android:name="android.permission.CAMERA" />
```

Then I went back to the demo site and verified the camera options were missing. In fact, we go straight to the file picker.

###  Before patch with camera permission declared

![device-2020-02-16-150140](https://user-images.githubusercontent.com/1542454/74614575-c9a87680-50cd-11ea-8c7b-15059a90ffc5.gif)

### After patch with camera permission declared

![device-2020-02-16-145914](https://user-images.githubusercontent.com/1542454/74614576-d0cf8480-50cd-11ea-921a-bc5c388a49e7.gif)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
