### PR TITLE
Fix: Moved readonly definition in WebViewTypes.ts

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -272,7 +272,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   saveFormDataDisabled?: boolean;
   textZoom?: number;
   thirdPartyCookiesEnabled?: boolean;
-  urlPrefixesForDefaultIntent?: readonly string[];
+  readonly urlPrefixesForDefaultIntent?: string[];
 }
 
 export enum ContentInsetAdjustmentBehavior {
@@ -291,7 +291,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   bounces?: boolean;
   contentInset?: ContentInsetProp;
   contentInsetAdjustmentBehavior?: ContentInsetAdjustmentBehavior;
-  dataDetectorTypes?: DataDetectorTypes | readonly DataDetectorTypes[];
+  readonly dataDetectorTypes?: DataDetectorTypes | DataDetectorTypes[];
   decelerationRate?: number;
   directionalLockEnabled?: boolean;
   hideKeyboardAccessoryView?: boolean;
@@ -409,7 +409,7 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    *
    * @platform ios
    */
-  dataDetectorTypes?: DataDetectorTypes | readonly DataDetectorTypes[];
+  readonly dataDetectorTypes?: DataDetectorTypes | DataDetectorTypes[];
 
   /**
    * Boolean that determines whether HTML5 videos play inline or use the
@@ -728,7 +728,7 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * Use this to list URLs that WebView cannot handle, e.g. a PDF url.
    * @platform android
    */
-  urlPrefixesForDefaultIntent?: readonly string[];
+  readonly urlPrefixesForDefaultIntent?: string[];
 
   /**
    * Boolean value to disable Hardware Acceleration in the `WebView`. Used on Android only
@@ -907,7 +907,7 @@ export interface WebViewSharedProps extends ViewProps {
    * this whitelist, we will open the URL in Safari.
    * The default whitelisted origins are "http://*" and "https://*".
    */
-  originWhitelist?: readonly string[];
+  readonly originWhitelist?: string[];
 
   /**
    * Function that allows custom handling of any web view requests. Return


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When you try to compile this lib in a project with a version of typescript < 3, it will fail.
It fails because the WebViewTypes.ts has the readonly definition, written in the wrong place.

this will resolve the following bug:
Bug when compile WebViewTypes.d.ts with Typescript #1267

## Test Plan
Compile with typescript version > 2

### What's required for testing (prerequisites)?
Typescript version 2 >

### What are the steps to reproduce (after prerequisites)?
The compilation of your project will not fail.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
