### PR TITLE
Ensure each mounted WebView binds their personal onMessage handler

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -398,6 +398,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   public void setMessagingEnabled(WebView view, boolean enabled) {
     ((RNCWebView) view).setMessagingEnabled(enabled);
   }
+
+  @ReactProp(name = "messagingModuleName")
+  public void setMessagingModuleName(WebView view, String moduleName) {
+    ((RNCWebView) view).setMessagingModuleName(moduleName);
+  }
    
   @ReactProp(name = "incognito")
   public void setIncognito(WebView view, boolean enabled) {
@@ -975,6 +980,8 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     String injectedJS;
     protected boolean messagingEnabled = false;
     protected @Nullable
+    String messagingModuleName;
+    protected @Nullable
     RNCWebViewClient mRNCWebViewClient;
     protected @Nullable
     CatalystInstance mCatalystInstance;
@@ -1076,6 +1083,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       }
     }
 
+    public void setMessagingModuleName(String moduleName) {
+      messagingModuleName = moduleName;
+    }
+
     protected void evaluateJavascriptWithFallback(String script) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
         evaluateJavascript(script, null);
@@ -1139,7 +1150,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       WritableNativeArray params = new WritableNativeArray();
       params.pushMap(event);
 
-      mCatalystInstance.callFunction("WebViewMessageHandler", "onMessage", params);
+      mCatalystInstance.callFunction(messagingModuleName, "onMessage", params);
     }
 
     protected void onScrollChanged(int x, int y, int oldX, int oldY) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "escape-string-regexp": "2.0.0",
     "invariant": "2.2.4",
-    "rnpm-plugin-windows": "^0.5.1-0"
+    "rnpm-plugin-windows": "^0.5.1-0",
+    "uuid": "^7.0.3"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",
@@ -48,6 +49,7 @@
     "@types/jest": "24.0.18",
     "@types/react": "16.8.8",
     "@types/react-native": "0.60.11",
+    "@types/uuid": "^7.0.2",
     "@typescript-eslint/eslint-plugin": "2.1.0",
     "@typescript-eslint/parser": "2.1.0",
     "babel-eslint": "10.0.3",

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { v4 as uuid } from 'uuid';
 
 import {
   Image,
@@ -70,7 +71,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     lastErrorEvent: null,
   };
 
-  uniqueRef = Math.floor(Math.random() * 10000000000);
+  uniqueRef = uuid().replace(/-/g, '');
 
   webViewRef = React.createRef<NativeWebViewAndroid>();
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -70,11 +70,15 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     lastErrorEvent: null,
   };
 
+  uniqueRef = Math.floor(Math.random() * 10000000000);
+
   webViewRef = React.createRef<NativeWebViewAndroid>();
 
   componentDidMount = () => {
-    BatchedBridge.registerCallableModule('WebViewMessageHandler', this);
+    BatchedBridge.registerCallableModule(this.getMessagingModuleName(), this);
   }
+
+  getMessagingModuleName = () => `WebViewMessageHandler${this.uniqueRef}`;
 
   getCommands = () => UIManager.getViewManagerConfig('RNCWebView').Commands;
 
@@ -333,6 +337,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
         key="webViewKey"
         {...otherProps}
         messagingEnabled={typeof onMessage === 'function'}
+        messagingModuleName={this.getMessagingModuleName()}
         onLoadingError={this.onLoadingError}
         onLoadingFinish={this.onLoadingFinish}
         onLoadingProgress={this.onLoadingProgress}

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -272,6 +272,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   saveFormDataDisabled?: boolean;
   textZoom?: number;
   thirdPartyCookiesEnabled?: boolean;
+  messagingModuleName?: string;
   readonly urlPrefixesForDefaultIntent?: string[];
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,6 +1502,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/uuid@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-7.0.2.tgz#d680a9c596ef84abf5c4c07a32ffd66d582526f8"
+  integrity sha512-8Ly3zIPTnT0/8RCU6Kg/G3uTICf9sRwYOpUzSIM3503tLIKcnJPRuinHhXngJUy2MntrEf6dlpOHXJju90Qh5w==
+
 "@types/yargs-parser@*":
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.0.0.tgz#453743c5bbf9f1bed61d959baab5b06be029b2d0"
@@ -10153,6 +10158,11 @@ uuid@^3.3.2, uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
# Summary
Fixes
- https://github.com/react-native-community/react-native-webview/issues/1295
- https://github.com/react-native-community/react-native-webview/issues/1300

which were introduced in 9.1.0 after merging https://github.com/react-native-community/react-native-webview/pull/1203

This is done by binding a separate module to each WebView that is used.

Unfortunately I came up with no better way to do the uniqueness except by a random string. If anyone has any ideas, I'm all ears.
Other things I tried:
- ref, which is not easily converted to a unique string
- nativeTag, which is a private parameter on Component
- UUID, for generation of which we'd need to include a library

## Test Plan

### What are the steps to reproduce (after prerequisites)?
- Include two separate WebView components with a unique onMessage handler for each
- Send a message to React Native layer from within each WebView
- Observe correct onMessage handlers called by calling console.log

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ✅ ] I have tested this on a device and a simulator
- [ N/A ] I added the documentation in `README.md`
- [ N/A ] I mentioned this change in `CHANGELOG.md`
- [ N/A ] I updated the typed files (TS and Flow)
- [ N/A ] I added a sample use of the API in the example project (`example/App.js`)
