### PR TITLE
Fix windows ScriptNotify and InjectJavaScript

### DIFF
--- a/windows/ReactNativeWebView/ReactWebViewManager.cpp
+++ b/windows/ReactNativeWebView/ReactWebViewManager.cpp
@@ -116,6 +116,7 @@ namespace winrt::ReactNativeWebView::implementation {
         FrameworkElement const& view,
         int64_t commandId,
         winrt::IJSValueReader const& commandArgsReader) noexcept {
+        auto commandArgs = JSValue::ReadArrayFrom(commandArgsReader);
         if (auto webView = view.try_as<winrt::WebView>()) {
             switch (commandId) {
                 case static_cast<int64_t>(WebViewCommands::GoForward) :
@@ -135,7 +136,7 @@ namespace winrt::ReactNativeWebView::implementation {
                     webView.Stop();
                     break;
                 case static_cast<int64_t>(WebViewCommands::InjectJavaScript) :
-                    webView.InvokeScriptAsync(L"eval", { commandArgsReader.GetString() });
+                    webView.InvokeScriptAsync(L"eval", { winrt::to_hstring(commandArgs[0].AsString()) });
                     break;
             }
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fix ScriptNotify to allow for JSON objects - the alert handler shouldn't consume any and all json objects. I also prefixed the type with double underscore to avoid collision with valid use cases where someone might want to use "type":"alert"

Fix InjectJavaScript, which wasn't parsing the command args correctly and so was always injecting an empty string.

## Test Plan

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
