### PR TITLE
add missing null check for fileTypes

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -335,7 +335,11 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
       // convert file extensions to mime types
       if (t.matches("\\.\\w+")) {
         String mimeType = getMimeTypeFromExtension(t.replace(".", ""));
-        mimeTypes[i] = mimeType;
+        if(mimeType != null) {
+          mimeTypes[i] = mimeType;
+        } else {
+          mimeTypes[i] = t;
+        }
       } else {
         mimeTypes[i] = t;
       }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -404,7 +404,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
     // when our array returned from getAcceptTypes() has no values set from the webview
     // i.e. <input type="file" />, without any "accept" attr
     // will be an array with one empty string element, afaik
-    return arr.length == 0 || (arr.length == 1 && arr[0].length() == 0);
+    return arr.length == 0 || (arr.length == 1 && arr[0] != null && arr[0].length() == 0);
   }
 
   private PermissionAwareActivity getPermissionAwareActivity() {


### PR DESCRIPTION
fixes #1121
when requesting a file upload with an unknown extension on android, getAcceptedMimeType returns [null] resulting in an exception when trying to test if array is empty.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

fixes #1121

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
see https://github.com/react-native-community/react-native-webview/issues/1121#issuecomment-625230364

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
