### PR TITLE
[DOCS] Fix broken link in docs/Guide.md

### DIFF
--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -505,7 +505,7 @@ const CustomHeaderWebView = props => {
 
 You can set cookies on the React Native side using the [@react-native-community/cookies](https://github.com/react-native-community/cookies) package.
 
-When you do, you'll likely want to enable the [sharedCookiesEnabled](Reference#sharedCookiesEnabled) prop as well.
+When you do, you'll likely want to enable the [sharedCookiesEnabled](Reference.md#sharedCookiesEnabled) prop as well.
 
 ```jsx
 const App = () => {


### PR DESCRIPTION
# Summary
The link here: https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#managing-cookies is broken. Let's fix it.

