### PR TITLE
Add SSL error handling for Android WebView

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.Manifest;
+import android.net.http.SslError;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -26,6 +27,7 @@ import android.webkit.CookieManager;
 import android.webkit.DownloadListener;
 import android.webkit.GeolocationPermissions;
 import android.webkit.JavascriptInterface;
+import android.webkit.SslErrorHandler;
 import android.webkit.PermissionRequest;
 import android.webkit.URLUtil;
 import android.webkit.ValueCallback;
@@ -779,6 +781,50 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       return this.shouldOverrideUrlLoading(view, url);
     }
 
+    @Override
+    public void onReceivedSslError(final WebView webView, final SslErrorHandler handler, final SslError error) {
+        handler.cancel();
+
+        int code = error.getPrimaryError();
+        String failingUrl = error.getUrl();
+        String description = "";
+        String descriptionPrefix = "SSL error: ";
+
+        // https://developer.android.com/reference/android/net/http/SslError.html
+        switch (code) {
+          case SslError.SSL_DATE_INVALID:
+            description = "The date of the certificate is invalid";
+            break;
+          case SslError.SSL_EXPIRED:
+            description = "The certificate has expired";
+            break;
+          case SslError.SSL_IDMISMATCH:
+            description = "Hostname mismatch";
+            break;
+          case SslError.SSL_INVALID:
+            description = "A generic error occurred";
+            break;
+          case SslError.SSL_NOTYETVALID:
+            description = "The certificate is not yet valid";
+            break;
+          case SslError.SSL_UNTRUSTED:
+            description = "The certificate authority is not trusted";
+            break;
+          default: 
+            description = "Unknown SSL Error";
+            break;
+        }
+        
+        description = descriptionPrefix + description;
+
+        this.onReceivedError(
+          webView,
+          code,
+          description,
+          failingUrl
+        );
+    }
+    
     @Override
     public void onReceivedError(
       WebView webView,


### PR DESCRIPTION
# Summary

Add SSL error handling, based on changes from PR #668 by @eahrold. Fixes security issues in apps which depend on `onError` being emitted for non-successful page loads, including SSL errors.

Navigations are cancelled and error is shown to user by default. No option is given to user to continue.

The only differences between PR #668 and this PR are:
* This PR excludes the unnecessary `SSL_MAX_ERROR` case, since it is never called per Android docs.
* This PR prefixes error descriptions with `SSL error:` to provide users and developers with more context, since some error messages do not provide sufficient context. Makes it more compatible with existing custom error screens too.

To quote the original PR:
> On android the JS `react-native-webview` WebView was not calling `onError` event or `renderError` when visiting a site with an invalid SSL certificate. Leaving the page blank.
> 
> This PR adds explicit handling to SSL errors by overriding
> 
> ```java
>  public void onReceivedSslError(final WebView webView, final SslErrorHandler handler, final SslError error) {
> ```
> 
> In the [RNCWebViewManager.java -> RNCWebViewClient](https://github.com/react-native-community/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java#L591)
> 
> It uses descriptions from error code provided here https://developer.android.com/reference/android/net/http/SslError.html
> 
> This should have minimal impact, and should not affect any custom implementations.

## Test Plan
### What's required for testing (prerequisites)?

Set up a basic WebView. Optionally add `onError` handler.

```js
import { WebView } from 'react-native-webview'

<WebView source={{ uri: "https://wrong.host.badssl.com" }} />
```

### What are the steps to reproduce (after prerequisites)?

1. Navigate to a page which results in an SSL error, such as https://wrong.host.badssl.com

By default, the following screen is shown within the WebView:
![ReactNativeWebView-SSL-error](https://user-images.githubusercontent.com/1619599/84229849-993f7a80-aab8-11ea-91dc-b065e966a7c4.jpg)

With a custom `onError` handler, the event is sent to the handler for custom processing, if the app already shows its own custom error page. This behavior makes the change backwards compatible while still resolving the security issues.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [`No docs needed`] I added the documentation in `README.md`
- [`There's no CHANGELOG.md? 😕`] I mentioned this change in `CHANGELOG.md`
- [`N/A`] I updated the typed files (TS and Flow)
- [`N/A`] I added a sample use of the API in the example project (`example/App.js`)
