### PR TITLE
support for compileSdkVersion=28

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -273,7 +273,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
 
   public boolean grantFileDownloaderPermissions() {
     // Permission not required for Android Q and above
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
       return true;
     }
 


### PR DESCRIPTION
# Summary
Issue fix for "Build is breaking for compileSdkVersion 28" - https://github.com/react-native-community/react-native-webview/issues/1437
https://github.com/react-native-community/react-native-webview/issues/1438

## Test Plan
Tested by correcting plugin and running on Mobile

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅   |

## Checklist
- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
