### PR TITLE
Synchronous onShouldStartLoadWithRequest for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Pods/
 .gradle
 local.properties
 lib/android/src/main/gen
+.cxx/
 
 # node.js
 #

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,15 @@ def getExtOrIntegerDefault(name) {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+task extractSo(type: Copy) {
+  from zipTree("${project.rootDir}/../node_modules/react-native/android/com/facebook/react/react-native/0.62.2/react-native-0.62.2.aar")
+  into "${buildDir}/_libraries/"
+  include "jni/**/libjscexecutor.so"
+
+}
+preBuild.dependsOn(extractSo)
+
+
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
@@ -45,6 +54,11 @@ android {
     ndk {
       moduleName "reactnativecommunity-webview"
       ldLibs "log"
+    }
+    externalNativeBuild {
+      ndkBuild {
+        arguments "BUILD_DIR=${buildDir}"
+      }
     }
   }
   buildTypes {
@@ -149,3 +163,4 @@ dependencies {
   implementation 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
+

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,10 @@ android {
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"
+    ndk {
+      moduleName "reactnativecommunity-webview"
+      ldLibs "log"
+    }
   }
   buildTypes {
     release {
@@ -54,6 +58,16 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
+  }
+  sourceSets {
+    main {
+      jni.srcDirs = ["src/main/cpp"]
+    }
+  }
+  externalNativeBuild {
+    ndkBuild {
+      path file('src/main/jni/Android.mk')
+    }
   }
 }
 

--- a/android/src/main/cpp/RNCWebViewJniUtils.cpp
+++ b/android/src/main/cpp/RNCWebViewJniUtils.cpp
@@ -2,6 +2,12 @@
 #include <stdexcept>
 
 #include "RNCWebViewJniUtils.h"
+#include "jsi/jsi.h"
+
+
+using facebook::jsi::JSIException;
+using facebook::jsi::JSINativeException;
+using facebook::jsi::JSError;
 
 
 // This is how we represent a Java exception already in progress
@@ -35,12 +41,15 @@ void swallow_cpp_exception_and_throw_java(JNIEnv * env) {
     throw;
   } catch(const ThrownJavaException&) {
     // already reported to Java, ignore
-  } catch(const std::bad_alloc& rhs) {
+  } catch(const JSError& e) {
+    NewJavaException(env, "com/reactnativecommunity/webview/jsi/JsiJSError", e.what());
+  } catch(const JSINativeException& e) {
+    NewJavaException(env, "com/reactnativecommunity/webview/jsi/JsiException", e.what());
+  } catch(const JSIException& e) {
+    NewJavaException(env, "com/reactnativecommunity/webview/jsi/JsiException", e.what());
+  } catch(const std::bad_alloc& e) {
     // translate OOM C++ exception to a Java exception
-    NewJavaException(env, "java/lang/OutOfMemoryError", rhs.what());
-  } catch(const std::ios_base::failure& rhs) { //sample translation
-    // translate IO C++ exception to a Java exception
-    NewJavaException(env, "java/io/IOException", rhs.what());
+    NewJavaException(env, "java/lang/OutOfMemoryError", e.what());
   } catch(const std::exception& e) {
     // translate unknown C++ exception to a Java exception
     NewJavaException(env, "java/lang/RuntimeException", e.what());

--- a/android/src/main/cpp/RNCWebViewJniUtils.cpp
+++ b/android/src/main/cpp/RNCWebViewJniUtils.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <stdexcept>
+
+#include "RNCWebViewJniUtils.h"
+
+
+// This is how we represent a Java exception already in progress
+struct ThrownJavaException : std::runtime_error {
+    ThrownJavaException() :std::runtime_error("") {}
+    ThrownJavaException(const std::string& msg ) :std::runtime_error(msg) {}
+};
+
+inline void assert_no_exception(JNIEnv * env) {
+  if (env->ExceptionCheck()==JNI_TRUE)
+    throw ThrownJavaException("assert_no_exception");
+}
+
+// used to throw a new Java exception. use full paths like:
+// "java/lang/NoSuchFieldException"
+// "java/lang/NullPointerException"
+// "java/security/InvalidParameterException"
+struct NewJavaException : public ThrownJavaException{
+    NewJavaException(JNIEnv * env, const char* type="", const char* message="")
+      :ThrownJavaException(type+std::string(" ")+message)
+    {
+      jclass newExcCls = env->FindClass(type);
+      if (newExcCls != NULL)
+        env->ThrowNew(newExcCls, message);
+      //if it is null, a NoClassDefFoundError was already thrown
+    }
+};
+
+void swallow_cpp_exception_and_throw_java(JNIEnv * env) {
+  try {
+    throw;
+  } catch(const ThrownJavaException&) {
+    // already reported to Java, ignore
+  } catch(const std::bad_alloc& rhs) {
+    // translate OOM C++ exception to a Java exception
+    NewJavaException(env, "java/lang/OutOfMemoryError", rhs.what());
+  } catch(const std::ios_base::failure& rhs) { //sample translation
+    // translate IO C++ exception to a Java exception
+    NewJavaException(env, "java/io/IOException", rhs.what());
+  } catch(const std::exception& e) {
+    // translate unknown C++ exception to a Java exception
+    NewJavaException(env, "java/lang/RuntimeException", e.what());
+  } catch(...) {
+    // translate unknown C++ exception to a Java exception
+    NewJavaException(env, "java/lang/Error", "Unknown exception type");
+  }
+}
+
+std::string jstring2string(JNIEnv *env, jstring jStr) {
+  if (!jStr)
+    return "";
+
+  const jclass stringClass = env->GetObjectClass(jStr);
+  const jmethodID getBytes = env->GetMethodID(stringClass, "getBytes", "(Ljava/lang/String;)[B");
+  const jbyteArray stringJbytes =
+      (jbyteArray) env->CallObjectMethod(jStr, getBytes, env->NewStringUTF("UTF-8"));
+
+  size_t length = (size_t) env->GetArrayLength(stringJbytes);
+  jbyte* pBytes = env->GetByteArrayElements(stringJbytes, NULL);
+
+  std::string ret = std::string((char *)pBytes, length);
+  env->ReleaseByteArrayElements(stringJbytes, pBytes, JNI_ABORT);
+
+  env->DeleteLocalRef(stringJbytes);
+  env->DeleteLocalRef(stringClass);
+  return ret;
+}

--- a/android/src/main/cpp/RNCWebViewJniUtils.h
+++ b/android/src/main/cpp/RNCWebViewJniUtils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#define UNUSED(x) (void)(x);
+
+#include <jni.h>
+#include <string>
+
+std::string jstring2string(JNIEnv *env, jstring jStr);
+void swallow_cpp_exception_and_throw_java(JNIEnv * env);

--- a/android/src/main/cpp/RNCWebViewJsiInterface.cpp
+++ b/android/src/main/cpp/RNCWebViewJsiInterface.cpp
@@ -1,4 +1,6 @@
 #include "RNCWebViewJsiInterface.h"
+
+#include "jsi/jsi.h"
 #include "RNCWebViewJniUtils.h"
 
 #define LOG_TAG "RNCWebViewJsiInterface"

--- a/android/src/main/cpp/RNCWebViewJsiInterface.cpp
+++ b/android/src/main/cpp/RNCWebViewJsiInterface.cpp
@@ -1,0 +1,48 @@
+#include "RNCWebViewJsiInterface.h"
+#include "RNCWebViewJniUtils.h"
+
+#define LOG_TAG "RNCWebViewJsiInterface"
+#include "RNCWebViewLoggingMacros.h"
+
+
+using namespace facebook;
+
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_reactnativecommunity_webview_jsi_WebViewJsiInterface_onShouldStartLoadWithRequest(
+  JNIEnv* env,
+  jobject thiz,
+  jlong runtimePtr,
+  jstring key,
+  jstring url,
+  jboolean loading,
+  jstring title,
+  jboolean canGoBack,
+  jboolean canGoForward)
+{
+  UNUSED(thiz);
+
+  auto *runtime = (jsi::Runtime *)runtimePtr;
+  if (runtime != nullptr) {
+    auto rncWebViewGlobal = runtime->global().getPropertyAsObject(*runtime, "RNCWebView");
+    auto onShouldStartLoadWithRequest =
+        rncWebViewGlobal.getPropertyAsFunction(*runtime, env->GetStringUTFChars(key, 0));
+    try {
+      auto nativeEvent = jsi::Object(*runtime);
+      nativeEvent.setProperty(*runtime, "url", jstring2string(env, url));
+      nativeEvent.setProperty(*runtime, "title", jstring2string(env, title));
+      nativeEvent.setProperty(*runtime, "loading", (bool)(loading == JNI_TRUE));
+      nativeEvent.setProperty(*runtime, "canGoBack", (bool)(canGoBack == JNI_TRUE));
+      nativeEvent.setProperty(*runtime, "canGoForward", (bool)(canGoForward == JNI_TRUE));
+
+      auto result = onShouldStartLoadWithRequest.call(*runtime, std::move(nativeEvent));
+      return (jboolean)(result.getBool() ? JNI_TRUE : JNI_FALSE);
+    } catch (...) {
+      swallow_cpp_exception_and_throw_java(env);
+      return JNI_FALSE;
+    }
+  } else {
+    LOGE("Unexpected null JSI runtime found! Falling back to allowing request.");
+    return JNI_FALSE;
+  }
+}

--- a/android/src/main/cpp/RNCWebViewJsiInterface.h
+++ b/android/src/main/cpp/RNCWebViewJsiInterface.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <jni.h>
-#include <jsi/jsi.h>
 
 
 extern "C" {

--- a/android/src/main/cpp/RNCWebViewJsiInterface.h
+++ b/android/src/main/cpp/RNCWebViewJsiInterface.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <jni.h>
+#include <jsi/jsi.h>
+
+
+extern "C" {
+  JNIEXPORT jboolean JNICALL
+  Java_com_reactnativecommunity_webview_jsi_WebViewJsiInterface_onShouldStartLoadWithRequest(
+    JNIEnv* env,
+    jobject thiz,
+    jlong runtimePtr,
+    jstring key,
+    jstring url,
+    jboolean loading,
+    jstring title,
+    jboolean canGoBack,
+    jboolean canGoForward
+  );
+}

--- a/android/src/main/cpp/RNCWebViewLoggingMacros.h
+++ b/android/src/main/cpp/RNCWebViewLoggingMacros.h
@@ -1,0 +1,21 @@
+#pragma once
+
+# ifdef ANDROID
+// LOGS ANDROID
+#   include <android/log.h>
+#   define LOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, LOG_TAG,__VA_ARGS__)
+#   define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG  , LOG_TAG,__VA_ARGS__)
+#   define LOGI(...) __android_log_print(ANDROID_LOG_INFO   , LOG_TAG,__VA_ARGS__)
+#   define LOGW(...) __android_log_print(ANDROID_LOG_WARN   , LOG_TAG,__VA_ARGS__)
+#   define LOGE(...) __android_log_print(ANDROID_LOG_ERROR  , LOG_TAG,__VA_ARGS__)
+#   define LOGSIMPLE(...)
+# else
+// LOGS NO ANDROID
+#   include <stdio.h>
+#   define LOGV(...) printf("  ");printf(__VA_ARGS__); printf("\t -  <%s> \n", LOG_TAG);
+#   define LOGD(...) printf("  ");printf(__VA_ARGS__); printf("\t -  <%s> \n", LOG_TAG);
+#   define LOGI(...) printf("  ");printf(__VA_ARGS__); printf("\t -  <%s> \n", LOG_TAG);
+#   define LOGW(...) printf("  * Warning: "); printf(__VA_ARGS__); printf("\t -  <%s> \n", LOG_TAG);
+#   define LOGE(...) printf("  *** Error:  ");printf(__VA_ARGS__); printf("\t -  <%s> \n", LOG_TAG);
+#   define LOGSIMPLE(...) printf(" ");printf(__VA_ARGS__);
+# endif // ANDROID

--- a/android/src/main/cpp/jsi/jsi-inl.h
+++ b/android/src/main/cpp/jsi/jsi-inl.h
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook {
+namespace jsi {
+namespace detail {
+
+inline Value toValue(Runtime&, std::nullptr_t) {
+  return Value::null();
+}
+inline Value toValue(Runtime&, bool b) {
+  return Value(b);
+}
+inline Value toValue(Runtime&, double d) {
+  return Value(d);
+}
+inline Value toValue(Runtime&, float f) {
+  return Value(static_cast<double>(f));
+}
+inline Value toValue(Runtime&, int i) {
+  return Value(i);
+}
+inline Value toValue(Runtime& runtime, const char* str) {
+  return String::createFromAscii(runtime, str);
+}
+inline Value toValue(Runtime& runtime, const std::string& str) {
+  return String::createFromAscii(runtime, str);
+}
+template <typename T>
+inline Value toValue(Runtime& runtime, const T& other) {
+  static_assert(
+      std::is_base_of<Pointer, T>::value,
+      "This type cannot be converted to Value");
+  return Value(runtime, other);
+}
+inline Value toValue(Runtime& runtime, const Value& value) {
+  return Value(runtime, value);
+}
+inline Value&& toValue(Runtime&, Value&& value) {
+  return std::move(value);
+}
+
+inline PropNameID toPropNameID(Runtime& runtime, const char* name) {
+  return PropNameID::forAscii(runtime, name);
+}
+inline PropNameID toPropNameID(Runtime& runtime, const std::string& name) {
+  return PropNameID::forUtf8(runtime, name);
+}
+inline PropNameID&& toPropNameID(Runtime&, PropNameID&& name) {
+  return std::move(name);
+}
+
+void throwJSError(Runtime&, const char* msg);
+
+} // namespace detail
+
+template <typename T>
+inline T Runtime::make(Runtime::PointerValue* pv) {
+  return T(pv);
+}
+
+inline const Runtime::PointerValue* Runtime::getPointerValue(
+    const jsi::Pointer& pointer) {
+  return pointer.ptr_;
+}
+
+inline const Runtime::PointerValue* Runtime::getPointerValue(
+    const jsi::Value& value) {
+  return value.data_.pointer.ptr_;
+}
+
+inline Value Object::getProperty(Runtime& runtime, const char* name) const {
+  return getProperty(runtime, String::createFromAscii(runtime, name));
+}
+
+inline Value Object::getProperty(Runtime& runtime, const String& name) const {
+  return runtime.getProperty(*this, name);
+}
+
+inline Value Object::getProperty(Runtime& runtime, const PropNameID& name)
+    const {
+  return runtime.getProperty(*this, name);
+}
+
+inline bool Object::hasProperty(Runtime& runtime, const char* name) const {
+  return hasProperty(runtime, String::createFromAscii(runtime, name));
+}
+
+inline bool Object::hasProperty(Runtime& runtime, const String& name) const {
+  return runtime.hasProperty(*this, name);
+}
+
+inline bool Object::hasProperty(Runtime& runtime, const PropNameID& name)
+    const {
+  return runtime.hasProperty(*this, name);
+}
+
+template <typename T>
+void Object::setProperty(Runtime& runtime, const char* name, T&& value) {
+  setProperty(
+      runtime, String::createFromAscii(runtime, name), std::forward<T>(value));
+}
+
+template <typename T>
+void Object::setProperty(Runtime& runtime, const String& name, T&& value) {
+  setPropertyValue(
+      runtime, name, detail::toValue(runtime, std::forward<T>(value)));
+}
+
+template <typename T>
+void Object::setProperty(Runtime& runtime, const PropNameID& name, T&& value) {
+  setPropertyValue(
+      runtime, name, detail::toValue(runtime, std::forward<T>(value)));
+}
+
+inline Array Object::getArray(Runtime& runtime) const& {
+  assert(runtime.isArray(*this));
+  (void)runtime; // when assert is disabled we need to mark this as used
+  return Array(runtime.cloneObject(ptr_));
+}
+
+inline Array Object::getArray(Runtime& runtime) && {
+  assert(runtime.isArray(*this));
+  (void)runtime; // when assert is disabled we need to mark this as used
+  Runtime::PointerValue* value = ptr_;
+  ptr_ = nullptr;
+  return Array(value);
+}
+
+inline ArrayBuffer Object::getArrayBuffer(Runtime& runtime) const& {
+  assert(runtime.isArrayBuffer(*this));
+  (void)runtime; // when assert is disabled we need to mark this as used
+  return ArrayBuffer(runtime.cloneObject(ptr_));
+}
+
+inline ArrayBuffer Object::getArrayBuffer(Runtime& runtime) && {
+  assert(runtime.isArrayBuffer(*this));
+  (void)runtime; // when assert is disabled we need to mark this as used
+  Runtime::PointerValue* value = ptr_;
+  ptr_ = nullptr;
+  return ArrayBuffer(value);
+}
+
+inline Function Object::getFunction(Runtime& runtime) const& {
+  assert(runtime.isFunction(*this));
+  return Function(runtime.cloneObject(ptr_));
+}
+
+inline Function Object::getFunction(Runtime& runtime) && {
+  assert(runtime.isFunction(*this));
+  (void)runtime; // when assert is disabled we need to mark this as used
+  Runtime::PointerValue* value = ptr_;
+  ptr_ = nullptr;
+  return Function(value);
+}
+
+template <typename T>
+inline bool Object::isHostObject(Runtime& runtime) const {
+  return runtime.isHostObject(*this) &&
+      std::dynamic_pointer_cast<T>(runtime.getHostObject(*this));
+}
+
+template <>
+inline bool Object::isHostObject<HostObject>(Runtime& runtime) const {
+  return runtime.isHostObject(*this);
+}
+
+template <typename T>
+inline std::shared_ptr<T> Object::getHostObject(Runtime& runtime) const {
+  assert(isHostObject<T>(runtime));
+  return std::static_pointer_cast<T>(runtime.getHostObject(*this));
+}
+
+template <typename T>
+inline std::shared_ptr<T> Object::asHostObject(Runtime& runtime) const {
+  if (!isHostObject<T>(runtime)) {
+    detail::throwJSError(runtime, "Object is not a HostObject of desired type");
+  }
+  return std::static_pointer_cast<T>(runtime.getHostObject(*this));
+}
+
+template <>
+inline std::shared_ptr<HostObject> Object::getHostObject<HostObject>(
+    Runtime& runtime) const {
+  assert(runtime.isHostObject(*this));
+  return runtime.getHostObject(*this);
+}
+
+inline Array Object::getPropertyNames(Runtime& runtime) const {
+  return runtime.getPropertyNames(*this);
+}
+
+inline Value WeakObject::lock(Runtime& runtime) {
+  return runtime.lockWeakObject(*this);
+}
+
+template <typename T>
+void Array::setValueAtIndex(Runtime& runtime, size_t i, T&& value) {
+  setValueAtIndexImpl(
+      runtime, i, detail::toValue(runtime, std::forward<T>(value)));
+}
+
+inline Value Array::getValueAtIndex(Runtime& runtime, size_t i) const {
+  return runtime.getValueAtIndex(*this, i);
+}
+
+inline Function Function::createFromHostFunction(
+    Runtime& runtime,
+    const jsi::PropNameID& name,
+    unsigned int paramCount,
+    jsi::HostFunctionType func) {
+  return runtime.createFunctionFromHostFunction(
+      name, paramCount, std::move(func));
+}
+
+inline Value Function::call(Runtime& runtime, const Value* args, size_t count)
+    const {
+  return runtime.call(*this, Value::undefined(), args, count);
+}
+
+inline Value Function::call(Runtime& runtime, std::initializer_list<Value> args)
+    const {
+  return call(runtime, args.begin(), args.size());
+}
+
+template <typename... Args>
+inline Value Function::call(Runtime& runtime, Args&&... args) const {
+  // A more awesome version of this would be able to create raw values
+  // which can be used directly without wrapping and unwrapping, but
+  // this will do for now.
+  return call(runtime, {detail::toValue(runtime, std::forward<Args>(args))...});
+}
+
+inline Value Function::callWithThis(
+    Runtime& runtime,
+    const Object& jsThis,
+    const Value* args,
+    size_t count) const {
+  return runtime.call(*this, Value(runtime, jsThis), args, count);
+}
+
+inline Value Function::callWithThis(
+    Runtime& runtime,
+    const Object& jsThis,
+    std::initializer_list<Value> args) const {
+  return callWithThis(runtime, jsThis, args.begin(), args.size());
+}
+
+template <typename... Args>
+inline Value Function::callWithThis(
+    Runtime& runtime,
+    const Object& jsThis,
+    Args&&... args) const {
+  // A more awesome version of this would be able to create raw values
+  // which can be used directly without wrapping and unwrapping, but
+  // this will do for now.
+  return callWithThis(
+      runtime, jsThis, {detail::toValue(runtime, std::forward<Args>(args))...});
+}
+
+template <typename... Args>
+inline Array Array::createWithElements(Runtime& runtime, Args&&... args) {
+  return createWithElements(
+      runtime, {detail::toValue(runtime, std::forward<Args>(args))...});
+}
+
+template <typename... Args>
+inline std::vector<PropNameID> PropNameID::names(
+    Runtime& runtime,
+    Args&&... args) {
+  return names({detail::toPropNameID(runtime, std::forward<Args>(args))...});
+}
+
+template <size_t N>
+inline std::vector<PropNameID> PropNameID::names(
+    PropNameID(&&propertyNames)[N]) {
+  std::vector<PropNameID> result;
+  result.reserve(N);
+  for (auto& name : propertyNames) {
+    result.push_back(std::move(name));
+  }
+  return result;
+}
+
+inline Value Function::callAsConstructor(
+    Runtime& runtime,
+    const Value* args,
+    size_t count) const {
+  return runtime.callAsConstructor(*this, args, count);
+}
+
+inline Value Function::callAsConstructor(
+    Runtime& runtime,
+    std::initializer_list<Value> args) const {
+  return callAsConstructor(runtime, args.begin(), args.size());
+}
+
+template <typename... Args>
+inline Value Function::callAsConstructor(Runtime& runtime, Args&&... args)
+    const {
+  return callAsConstructor(
+      runtime, {detail::toValue(runtime, std::forward<Args>(args))...});
+}
+
+} // namespace jsi
+} // namespace facebook

--- a/android/src/main/cpp/jsi/jsi.h
+++ b/android/src/main/cpp/jsi/jsi.h
@@ -1,0 +1,1277 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <cstring>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifndef JSI_EXPORT
+#ifdef _MSC_VER
+#ifdef JSI_CREATE_SHARED_LIBRARY
+#define JSI_EXPORT __declspec(dllexport)
+#else
+#define JSI_EXPORT
+#endif // JSI_CREATE_SHARED_LIBRARY
+#else // _MSC_VER
+#define JSI_EXPORT __attribute__((visibility("default")))
+#endif // _MSC_VER
+#endif // !defined(JSI_EXPORT)
+
+class FBJSRuntime;
+namespace facebook {
+namespace jsi {
+
+class Buffer {
+ public:
+  virtual ~Buffer();
+  virtual size_t size() const = 0;
+  virtual const uint8_t* data() const = 0;
+};
+
+class StringBuffer : public Buffer {
+ public:
+  StringBuffer(std::string s) : s_(std::move(s)) {}
+  size_t size() const override {
+    return s_.size();
+  }
+  const uint8_t* data() const override {
+    return reinterpret_cast<const uint8_t*>(s_.data());
+  }
+
+ private:
+  std::string s_;
+};
+
+/// PreparedJavaScript is a base class representing JavaScript which is in a form
+/// optimized for execution, in a runtime-specific way. Construct one via
+/// jsi::Runtime::prepareJavaScript().
+/// ** This is an experimental API that is subject to change. **
+class PreparedJavaScript {
+ protected:
+  PreparedJavaScript() = default;
+
+ public:
+  virtual ~PreparedJavaScript() = 0;
+};
+
+class Runtime;
+class Pointer;
+class PropNameID;
+class Symbol;
+class String;
+class Object;
+class WeakObject;
+class Array;
+class ArrayBuffer;
+class Function;
+class Value;
+class Instrumentation;
+class Scope;
+class JSIException;
+class JSError;
+
+/// A function which has this type can be registered as a function
+/// callable from JavaScript using Function::createFromHostFunction().
+/// When the function is called, args will point to the arguments, and
+/// count will indicate how many arguments are passed.  The function
+/// can return a Value to the caller, or throw an exception.  If a C++
+/// exception is thrown, a JS Error will be created and thrown into
+/// JS; if the C++ exception extends std::exception, the Error's
+/// message will be whatever what() returns. Note that it is undefined whether
+/// HostFunctions may or may not be called in strict mode; that is `thisVal`
+/// can be any value - it will not necessarily be coerced to an object or
+/// or set to the global object.
+using HostFunctionType = std::function<
+    Value(Runtime& rt, const Value& thisVal, const Value* args, size_t count)>;
+
+/// An object which implements this interface can be registered as an
+/// Object with the JS runtime.
+class JSI_EXPORT HostObject {
+ public:
+  // The C++ object's dtor will be called when the GC finalizes this
+  // object.  (This may be as late as when the Runtime is shut down.)
+  // You have no control over which thread it is called on.  This will
+  // be called from inside the GC, so it is unsafe to do any VM
+  // operations which require a Runtime&.  Derived classes' dtors
+  // should also avoid doing anything expensive.  Calling the dtor on
+  // a jsi object is explicitly ok.  If you want to do JS operations,
+  // or any nontrivial work, you should add it to a work queue, and
+  // manage it externally.
+  virtual ~HostObject();
+
+  // When JS wants a property with a given name from the HostObject,
+  // it will call this method.  If it throws an exception, the call
+  // will throw a JS \c Error object. By default this returns undefined.
+  // \return the value for the property.
+  virtual Value get(Runtime&, const PropNameID& name);
+
+  // When JS wants to set a property with a given name on the HostObject,
+  // it will call this method. If it throws an exception, the call will
+  // throw a JS \c Error object. By default this throws a type error exception
+  // mimicking the behavior of a frozen object in strict mode.
+  virtual void set(Runtime&, const PropNameID& name, const Value& value);
+
+  // When JS wants a list of property names for the HostObject, it will
+  // call this method. If it throws an exception, the call will thow a
+  // JS \c Error object. The default implementation returns empty vector.
+  virtual std::vector<PropNameID> getPropertyNames(Runtime& rt);
+};
+
+/// Represents a JS runtime.  Movable, but not copyable.  Note that
+/// this object may not be thread-aware, but cannot be used safely from
+/// multiple threads at once.  The application is responsible for
+/// ensuring that it is used safely.  This could mean using the
+/// Runtime from a single thread, using a mutex, doing all work on a
+/// serial queue, etc.  This restriction applies to the methods of
+/// this class, and any method in the API which take a Runtime& as an
+/// argument.  Destructors (all but ~Scope), operators, or other methods
+/// which do not take Runtime& as an argument are safe to call from any
+/// thread, but it is still forbidden to make write operations on a single
+/// instance of any class from more than one thread.  In addition, to
+/// make shutdown safe, destruction of objects associated with the Runtime
+/// must be destroyed before the Runtime is destroyed, or from the
+/// destructor of a managed HostObject or HostFunction.  Informally, this
+/// means that the main source of unsafe behavior is to hold a jsi object
+/// in a non-Runtime-managed object, and not clean it up before the Runtime
+/// is shut down.  If your lifecycle is such that avoiding this is hard,
+/// you will probably need to do use your own locks.
+class Runtime {
+ public:
+  virtual ~Runtime();
+
+  /// Evaluates the given JavaScript \c buffer.  \c sourceURL is used
+  /// to annotate the stack trace if there is an exception.  The
+  /// contents may be utf8-encoded JS source code, or binary bytecode
+  /// whose format is specific to the implementation.  If the input
+  /// format is unknown, or evaluation causes an error, a JSIException
+  /// will be thrown.
+  /// Note this function should ONLY be used when there isn't another means
+  /// through the JSI API. For example, it will be much slower to use this to
+  /// call a global function than using the JSI APIs to read the function
+  /// property from the global object and then calling it explicitly.
+  virtual Value evaluateJavaScript(
+      const std::shared_ptr<const Buffer>& buffer,
+      const std::string& sourceURL) = 0;
+
+  /// Prepares to evaluate the given JavaScript \c buffer by processing it into
+  /// a form optimized for execution. This may include pre-parsing, compiling,
+  /// etc. If the input is invalid (for example, cannot be parsed), a
+  /// JSIException will be thrown. The resulting object is tied to the
+  /// particular concrete type of Runtime from which it was created. It may be
+  /// used (via evaluatePreparedJavaScript) in any Runtime of the same concrete
+  /// type.
+  /// The PreparedJavaScript object may be passed to multiple VM instances, so
+  /// they can all share and benefit from the prepared script.
+  /// As with evaluateJavaScript(), using JavaScript code should be avoided
+  /// when the JSI API is sufficient.
+  virtual std::shared_ptr<const PreparedJavaScript> prepareJavaScript(
+      const std::shared_ptr<const Buffer>& buffer,
+      std::string sourceURL) = 0;
+
+  /// Evaluates a PreparedJavaScript. If evaluation causes an error, a
+  /// JSIException will be thrown.
+  /// As with evaluateJavaScript(), using JavaScript code should be avoided
+  /// when the JSI API is sufficient.
+  virtual Value evaluatePreparedJavaScript(
+      const std::shared_ptr<const PreparedJavaScript>& js) = 0;
+
+  /// \return the global object
+  virtual Object global() = 0;
+
+  /// \return a short printable description of the instance.  This
+  /// should only be used by logging, debugging, and other
+  /// developer-facing callers.
+  virtual std::string description() = 0;
+
+  /// \return whether or not the underlying runtime supports debugging via the
+  /// Chrome remote debugging protocol.
+  ///
+  /// NOTE: the API for determining whether a runtime is debuggable and
+  /// registering a runtime with the debugger is still in flux, so please don't
+  /// use this API unless you know what you're doing.
+  virtual bool isInspectable() = 0;
+
+  /// \return an interface to extract metrics from this \c Runtime.  The default
+  /// implementation of this function returns an \c Instrumentation instance
+  /// which returns no metrics.
+  virtual Instrumentation& instrumentation();
+
+ protected:
+  friend class Pointer;
+  friend class PropNameID;
+  friend class Symbol;
+  friend class String;
+  friend class Object;
+  friend class WeakObject;
+  friend class Array;
+  friend class ArrayBuffer;
+  friend class Function;
+  friend class Value;
+  friend class Scope;
+  friend class JSError;
+
+  // Potential optimization: avoid the cloneFoo() virtual dispatch,
+  // and instead just fix the number of fields, and copy them, since
+  // in practice they are trivially copyable.  Sufficient use of
+  // rvalue arguments/methods would also reduce the number of clones.
+
+  struct PointerValue {
+    virtual void invalidate() = 0;
+
+   protected:
+    virtual ~PointerValue() = default;
+  };
+
+  virtual PointerValue* cloneSymbol(const Runtime::PointerValue* pv) = 0;
+  virtual PointerValue* cloneString(const Runtime::PointerValue* pv) = 0;
+  virtual PointerValue* cloneObject(const Runtime::PointerValue* pv) = 0;
+  virtual PointerValue* clonePropNameID(const Runtime::PointerValue* pv) = 0;
+
+  virtual PropNameID createPropNameIDFromAscii(
+      const char* str,
+      size_t length) = 0;
+  virtual PropNameID createPropNameIDFromUtf8(
+      const uint8_t* utf8,
+      size_t length) = 0;
+  virtual PropNameID createPropNameIDFromString(const String& str) = 0;
+  virtual std::string utf8(const PropNameID&) = 0;
+  virtual bool compare(const PropNameID&, const PropNameID&) = 0;
+
+  virtual std::string symbolToString(const Symbol&) = 0;
+
+  virtual String createStringFromAscii(const char* str, size_t length) = 0;
+  virtual String createStringFromUtf8(const uint8_t* utf8, size_t length) = 0;
+  virtual std::string utf8(const String&) = 0;
+
+  // \return a \c Value created from a utf8-encoded JSON string. The default
+  // implementation creates a \c String and invokes JSON.parse.
+  virtual Value createValueFromJsonUtf8(const uint8_t* json, size_t length);
+
+  virtual Object createObject() = 0;
+  virtual Object createObject(std::shared_ptr<HostObject> ho) = 0;
+  virtual std::shared_ptr<HostObject> getHostObject(const jsi::Object&) = 0;
+  virtual HostFunctionType& getHostFunction(const jsi::Function&) = 0;
+
+  virtual Value getProperty(const Object&, const PropNameID& name) = 0;
+  virtual Value getProperty(const Object&, const String& name) = 0;
+  virtual bool hasProperty(const Object&, const PropNameID& name) = 0;
+  virtual bool hasProperty(const Object&, const String& name) = 0;
+  virtual void
+  setPropertyValue(Object&, const PropNameID& name, const Value& value) = 0;
+  virtual void
+  setPropertyValue(Object&, const String& name, const Value& value) = 0;
+
+  virtual bool isArray(const Object&) const = 0;
+  virtual bool isArrayBuffer(const Object&) const = 0;
+  virtual bool isFunction(const Object&) const = 0;
+  virtual bool isHostObject(const jsi::Object&) const = 0;
+  virtual bool isHostFunction(const jsi::Function&) const = 0;
+  virtual Array getPropertyNames(const Object&) = 0;
+
+  virtual WeakObject createWeakObject(const Object&) = 0;
+  virtual Value lockWeakObject(const WeakObject&) = 0;
+
+  virtual Array createArray(size_t length) = 0;
+  virtual size_t size(const Array&) = 0;
+  virtual size_t size(const ArrayBuffer&) = 0;
+  virtual uint8_t* data(const ArrayBuffer&) = 0;
+  virtual Value getValueAtIndex(const Array&, size_t i) = 0;
+  virtual void setValueAtIndexImpl(Array&, size_t i, const Value& value) = 0;
+
+  virtual Function createFunctionFromHostFunction(
+      const PropNameID& name,
+      unsigned int paramCount,
+      HostFunctionType func) = 0;
+  virtual Value call(
+      const Function&,
+      const Value& jsThis,
+      const Value* args,
+      size_t count) = 0;
+  virtual Value
+  callAsConstructor(const Function&, const Value* args, size_t count) = 0;
+
+  // Private data for managing scopes.
+  struct ScopeState;
+  virtual ScopeState* pushScope();
+  virtual void popScope(ScopeState*);
+
+  virtual bool strictEquals(const Symbol& a, const Symbol& b) const = 0;
+  virtual bool strictEquals(const String& a, const String& b) const = 0;
+  virtual bool strictEquals(const Object& a, const Object& b) const = 0;
+
+  virtual bool instanceOf(const Object& o, const Function& f) = 0;
+
+  // These exist so derived classes can access the private parts of
+  // Value, Symbol, String, and Object, which are all friends of Runtime.
+  template <typename T>
+  static T make(PointerValue* pv);
+  static const PointerValue* getPointerValue(const Pointer& pointer);
+  static const PointerValue* getPointerValue(const Value& value);
+
+  friend class ::FBJSRuntime;
+  template <typename Plain, typename Base>
+  friend class RuntimeDecorator;
+};
+
+// Base class for pointer-storing types.
+class Pointer {
+ protected:
+  explicit Pointer(Pointer&& other) : ptr_(other.ptr_) {
+    other.ptr_ = nullptr;
+  }
+
+  ~Pointer() {
+    if (ptr_) {
+      ptr_->invalidate();
+    }
+  }
+
+  Pointer& operator=(Pointer&& other);
+
+  friend class Runtime;
+  friend class Value;
+
+  explicit Pointer(Runtime::PointerValue* ptr) : ptr_(ptr) {}
+
+  typename Runtime::PointerValue* ptr_;
+};
+
+/// Represents something that can be a JS property key.  Movable, not copyable.
+class PropNameID : public Pointer {
+ public:
+  using Pointer::Pointer;
+
+  PropNameID(Runtime& runtime, const PropNameID& other)
+      : Pointer(runtime.clonePropNameID(other.ptr_)) {}
+
+  PropNameID(PropNameID&& other) = default;
+  PropNameID& operator=(PropNameID&& other) = default;
+
+  /// Create a JS property name id from ascii values.  The data is
+  /// copied.
+  static PropNameID forAscii(Runtime& runtime, const char* str, size_t length) {
+    return runtime.createPropNameIDFromAscii(str, length);
+  }
+
+  /// Create a property name id from a nul-terminated C ascii name.  The data is
+  /// copied.
+  static PropNameID forAscii(Runtime& runtime, const char* str) {
+    return forAscii(runtime, str, strlen(str));
+  }
+
+  /// Create a PropNameID from a C++ string. The string is copied.
+  static PropNameID forAscii(Runtime& runtime, const std::string& str) {
+    return forAscii(runtime, str.c_str(), str.size());
+  }
+
+  /// Create a PropNameID from utf8 values.  The data is copied.
+  static PropNameID
+  forUtf8(Runtime& runtime, const uint8_t* utf8, size_t length) {
+    return runtime.createPropNameIDFromUtf8(utf8, length);
+  }
+
+  /// Create a PropNameID from utf8-encoded octets stored in a
+  /// std::string.  The string data is transformed and copied.
+  static PropNameID forUtf8(Runtime& runtime, const std::string& utf8) {
+    return runtime.createPropNameIDFromUtf8(
+        reinterpret_cast<const uint8_t*>(utf8.data()), utf8.size());
+  }
+
+  /// Create a PropNameID from a JS string.
+  static PropNameID forString(Runtime& runtime, const jsi::String& str) {
+    return runtime.createPropNameIDFromString(str);
+  }
+
+  // Creates a vector of PropNameIDs constructed from given arguments.
+  template <typename... Args>
+  static std::vector<PropNameID> names(Runtime& runtime, Args&&... args);
+
+  // Creates a vector of given PropNameIDs.
+  template <size_t N>
+  static std::vector<PropNameID> names(PropNameID(&&propertyNames)[N]);
+
+  /// Copies the data in a PropNameID as utf8 into a C++ string.
+  std::string utf8(Runtime& runtime) const {
+    return runtime.utf8(*this);
+  }
+
+  static bool compare(
+      Runtime& runtime,
+      const jsi::PropNameID& a,
+      const jsi::PropNameID& b) {
+    return runtime.compare(a, b);
+  }
+
+  friend class Runtime;
+  friend class Value;
+};
+
+/// Represents a JS Symbol (es6).  Movable, not copyable.
+/// TODO T40778724: this is a limited implementation sufficient for
+/// the debugger not to crash when a Symbol is a property in an Object
+/// or element in an array.  Complete support for creating will come
+/// later.
+class Symbol : public Pointer {
+ public:
+  using Pointer::Pointer;
+
+  Symbol(Symbol&& other) = default;
+  Symbol& operator=(Symbol&& other) = default;
+
+  /// \return whether a and b refer to the same symbol.
+  static bool strictEquals(Runtime& runtime, const Symbol& a, const Symbol& b) {
+    return runtime.strictEquals(a, b);
+  }
+
+  /// Converts a Symbol into a C++ string as JS .toString would.  The output
+  /// will look like \c Symbol(description) .
+  std::string toString(Runtime& runtime) const {
+    return runtime.symbolToString(*this);
+  }
+
+  friend class Runtime;
+  friend class Value;
+};
+
+/// Represents a JS String.  Movable, not copyable.
+class String : public Pointer {
+ public:
+  using Pointer::Pointer;
+
+  String(String&& other) = default;
+  String& operator=(String&& other) = default;
+
+  /// Create a JS string from ascii values.  The string data is
+  /// copied.
+  static String
+  createFromAscii(Runtime& runtime, const char* str, size_t length) {
+    return runtime.createStringFromAscii(str, length);
+  }
+
+  /// Create a JS string from a nul-terminated C ascii string.  The
+  /// string data is copied.
+  static String createFromAscii(Runtime& runtime, const char* str) {
+    return createFromAscii(runtime, str, strlen(str));
+  }
+
+  /// Create a JS string from a C++ string.  The string data is
+  /// copied.
+  static String createFromAscii(Runtime& runtime, const std::string& str) {
+    return createFromAscii(runtime, str.c_str(), str.size());
+  }
+
+  /// Create a JS string from utf8-encoded octets.  The string data is
+  /// transformed and copied.
+  static String
+  createFromUtf8(Runtime& runtime, const uint8_t* utf8, size_t length) {
+    return runtime.createStringFromUtf8(utf8, length);
+  }
+
+  /// Create a JS string from utf8-encoded octets stored in a
+  /// std::string.  The string data is transformed and copied.
+  static String createFromUtf8(Runtime& runtime, const std::string& utf8) {
+    return runtime.createStringFromUtf8(
+        reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length());
+  }
+
+  /// \return whether a and b contain the same characters.
+  static bool strictEquals(Runtime& runtime, const String& a, const String& b) {
+    return runtime.strictEquals(a, b);
+  }
+
+  /// Copies the data in a JS string as utf8 into a C++ string.
+  std::string utf8(Runtime& runtime) const {
+    return runtime.utf8(*this);
+  }
+
+  friend class Runtime;
+  friend class Value;
+};
+
+class Array;
+class Function;
+
+/// Represents a JS Object.  Movable, not copyable.
+class Object : public Pointer {
+ public:
+  using Pointer::Pointer;
+
+  Object(Object&& other) = default;
+  Object& operator=(Object&& other) = default;
+
+  /// Creates a new Object instance, like '{}' in JS.
+  Object(Runtime& runtime) : Object(runtime.createObject()) {}
+
+  static Object createFromHostObject(
+      Runtime& runtime,
+      std::shared_ptr<HostObject> ho) {
+    return runtime.createObject(ho);
+  }
+
+  /// \return whether this and \c obj are the same JSObject or not.
+  static bool strictEquals(Runtime& runtime, const Object& a, const Object& b) {
+    return runtime.strictEquals(a, b);
+  }
+
+  /// \return the result of `this instanceOf ctor` in JS.
+  bool instanceOf(Runtime& rt, const Function& ctor) {
+    return rt.instanceOf(*this, ctor);
+  }
+
+  /// \return the property of the object with the given ascii name.
+  /// If the name isn't a property on the object, returns the
+  /// undefined value.
+  Value getProperty(Runtime& runtime, const char* name) const;
+
+  /// \return the property of the object with the String name.
+  /// If the name isn't a property on the object, returns the
+  /// undefined value.
+  Value getProperty(Runtime& runtime, const String& name) const;
+
+  /// \return the property of the object with the given JS PropNameID
+  /// name.  If the name isn't a property on the object, returns the
+  /// undefined value.
+  Value getProperty(Runtime& runtime, const PropNameID& name) const;
+
+  /// \return true if and only if the object has a property with the
+  /// given ascii name.
+  bool hasProperty(Runtime& runtime, const char* name) const;
+
+  /// \return true if and only if the object has a property with the
+  /// given String name.
+  bool hasProperty(Runtime& runtime, const String& name) const;
+
+  /// \return true if and only if the object has a property with the
+  /// given PropNameID name.
+  bool hasProperty(Runtime& runtime, const PropNameID& name) const;
+
+  /// Sets the property value from a Value or anything which can be
+  /// used to make one: nullptr_t, bool, double, int, const char*,
+  /// String, or Object.
+  template <typename T>
+  void setProperty(Runtime& runtime, const char* name, T&& value);
+
+  /// Sets the property value from a Value or anything which can be
+  /// used to make one: nullptr_t, bool, double, int, const char*,
+  /// String, or Object.
+  template <typename T>
+  void setProperty(Runtime& runtime, const String& name, T&& value);
+
+  /// Sets the property value from a Value or anything which can be
+  /// used to make one: nullptr_t, bool, double, int, const char*,
+  /// String, or Object.
+  template <typename T>
+  void setProperty(Runtime& runtime, const PropNameID& name, T&& value);
+
+  /// \return true iff JS \c Array.isArray() would return \c true.  If
+  /// so, then \c getArray() will succeed.
+  bool isArray(Runtime& runtime) const {
+    return runtime.isArray(*this);
+  }
+
+  /// \return true iff the Object is an ArrayBuffer. If so, then \c
+  /// getArrayBuffer() will succeed.
+  bool isArrayBuffer(Runtime& runtime) const {
+    return runtime.isArrayBuffer(*this);
+  }
+
+  /// \return true iff the Object is callable.  If so, then \c
+  /// getFunction will succeed.
+  bool isFunction(Runtime& runtime) const {
+    return runtime.isFunction(*this);
+  }
+
+  /// \return true iff the Object was initialized with \c createFromHostObject
+  /// and the HostObject passed is of type \c T. If returns \c true then
+  /// \c getHostObject<T> will succeed.
+  template <typename T = HostObject>
+  bool isHostObject(Runtime& runtime) const;
+
+  /// \return an Array instance which refers to the same underlying
+  /// object.  If \c isArray() would return false, this will assert.
+  Array getArray(Runtime& runtime) const&;
+
+  /// \return an Array instance which refers to the same underlying
+  /// object.  If \c isArray() would return false, this will assert.
+  Array getArray(Runtime& runtime) &&;
+
+  /// \return an Array instance which refers to the same underlying
+  /// object.  If \c isArray() would return false, this will throw
+  /// JSIException.
+  Array asArray(Runtime& runtime) const&;
+
+  /// \return an Array instance which refers to the same underlying
+  /// object.  If \c isArray() would return false, this will throw
+  /// JSIException.
+  Array asArray(Runtime& runtime) &&;
+
+  /// \return an ArrayBuffer instance which refers to the same underlying
+  /// object.  If \c isArrayBuffer() would return false, this will assert.
+  ArrayBuffer getArrayBuffer(Runtime& runtime) const&;
+
+  /// \return an ArrayBuffer instance which refers to the same underlying
+  /// object.  If \c isArrayBuffer() would return false, this will assert.
+  ArrayBuffer getArrayBuffer(Runtime& runtime) &&;
+
+  /// \return a Function instance which refers to the same underlying
+  /// object.  If \c isFunction() would return false, this will assert.
+  Function getFunction(Runtime& runtime) const&;
+
+  /// \return a Function instance which refers to the same underlying
+  /// object.  If \c isFunction() would return false, this will assert.
+  Function getFunction(Runtime& runtime) &&;
+
+  /// \return a Function instance which refers to the same underlying
+  /// object.  If \c isFunction() would return false, this will throw
+  /// JSIException.
+  Function asFunction(Runtime& runtime) const&;
+
+  /// \return a Function instance which refers to the same underlying
+  /// object.  If \c isFunction() would return false, this will throw
+  /// JSIException.
+  Function asFunction(Runtime& runtime) &&;
+
+  /// \return a shared_ptr<T> which refers to the same underlying
+  /// \c HostObject that was used to create this object. If \c isHostObject<T>
+  /// is false, this will assert. Note that this does a type check and will
+  /// assert if the underlying HostObject isn't of type \c T
+  template <typename T = HostObject>
+  std::shared_ptr<T> getHostObject(Runtime& runtime) const;
+
+  /// \return a shared_ptr<T> which refers to the same underlying
+  /// \c HostObject that was used to crete this object. If \c isHostObject<T>
+  /// is false, this will throw.
+  template <typename T = HostObject>
+  std::shared_ptr<T> asHostObject(Runtime& runtime) const;
+
+  /// \return same as \c getProperty(name).asObject(), except with
+  /// a better exception message.
+  Object getPropertyAsObject(Runtime& runtime, const char* name) const;
+
+  /// \return similar to \c
+  /// getProperty(name).getObject().getFunction(), except it will
+  /// throw JSIException instead of asserting if the property is
+  /// not an object, or the object is not callable.
+  Function getPropertyAsFunction(Runtime& runtime, const char* name) const;
+
+  /// \return an Array consisting of all enumerable property names in
+  /// the object and its prototype chain.  All values in the return
+  /// will be isString().  (This is probably not optimal, but it
+  /// works.  I only need it in one place.)
+  Array getPropertyNames(Runtime& runtime) const;
+
+ protected:
+  void
+  setPropertyValue(Runtime& runtime, const String& name, const Value& value) {
+    return runtime.setPropertyValue(*this, name, value);
+  }
+
+  void setPropertyValue(
+      Runtime& runtime,
+      const PropNameID& name,
+      const Value& value) {
+    return runtime.setPropertyValue(*this, name, value);
+  }
+
+  friend class Runtime;
+  friend class Value;
+};
+
+/// Represents a weak reference to a JS Object.  If the only reference
+/// to an Object are these, the object is eligible for GC.  Method
+/// names are inspired by C++ weak_ptr.  Movable, not copyable.
+class WeakObject : public Pointer {
+ public:
+  using Pointer::Pointer;
+
+  WeakObject(WeakObject&& other) = default;
+  WeakObject& operator=(WeakObject&& other) = default;
+
+  /// Create a WeakObject from an Object.
+  WeakObject(Runtime& runtime, const Object& o)
+      : WeakObject(runtime.createWeakObject(o)) {}
+
+  /// \return a Value representing the underlying Object if it is still valid;
+  /// otherwise returns \c undefined.  Note that this method has nothing to do
+  /// with threads or concurrency.  The name is based on std::weak_ptr::lock()
+  /// which serves a similar purpose.
+  Value lock(Runtime& runtime);
+
+  friend class Runtime;
+};
+
+/// Represents a JS Object which can be efficiently used as an array
+/// with integral indices.
+class Array : public Object {
+ public:
+  Array(Array&&) = default;
+  /// Creates a new Array instance, with \c length undefined elements.
+  Array(Runtime& runtime, size_t length) : Array(runtime.createArray(length)) {}
+
+  Array& operator=(Array&&) = default;
+
+  /// \return the size of the Array, according to its length property.
+  /// (C++ naming convention)
+  size_t size(Runtime& runtime) const {
+    return runtime.size(*this);
+  }
+
+  /// \return the size of the Array, according to its length property.
+  /// (JS naming convention)
+  size_t length(Runtime& runtime) const {
+    return size(runtime);
+  }
+
+  /// \return the property of the array at index \c i.  If there is no
+  /// such property, returns the undefined value.  If \c i is out of
+  /// range [ 0..\c length ] throws a JSIException.
+  Value getValueAtIndex(Runtime& runtime, size_t i) const;
+
+  /// Sets the property of the array at index \c i.  The argument
+  /// value behaves as with Object::setProperty().  If \c i is out of
+  /// range [ 0..\c length ] throws a JSIException.
+  template <typename T>
+  void setValueAtIndex(Runtime& runtime, size_t i, T&& value);
+
+  /// There is no current API for changing the size of an array once
+  /// created.  We'll probably need that eventually.
+
+  /// Creates a new Array instance from provided values
+  template <typename... Args>
+  static Array createWithElements(Runtime&, Args&&... args);
+
+  /// Creates a new Array instance from initializer list.
+  static Array createWithElements(
+      Runtime& runtime,
+      std::initializer_list<Value> elements);
+
+ private:
+  friend class Object;
+  friend class Value;
+
+  void setValueAtIndexImpl(Runtime& runtime, size_t i, const Value& value) {
+    return runtime.setValueAtIndexImpl(*this, i, value);
+  }
+
+  Array(Runtime::PointerValue* value) : Object(value) {}
+};
+
+/// Represents a JSArrayBuffer
+class ArrayBuffer : public Object {
+ public:
+  ArrayBuffer(ArrayBuffer&&) = default;
+  ArrayBuffer& operator=(ArrayBuffer&&) = default;
+
+  /// \return the size of the ArrayBuffer, according to its byteLength property.
+  /// (C++ naming convention)
+  size_t size(Runtime& runtime) const {
+    return runtime.size(*this);
+  }
+
+  size_t length(Runtime& runtime) const {
+    return runtime.size(*this);
+  }
+
+  uint8_t* data(Runtime& runtime) {
+    return runtime.data(*this);
+  }
+
+ private:
+  friend class Object;
+  friend class Value;
+
+  ArrayBuffer(Runtime::PointerValue* value) : Object(value) {}
+};
+
+/// Represents a JS Object which is guaranteed to be Callable.
+class Function : public Object {
+ public:
+  Function(Function&&) = default;
+  Function& operator=(Function&&) = default;
+
+  /// Create a function which, when invoked, calls C++ code. If the
+  /// function throws an exception, a JS Error will be created and
+  /// thrown.
+  /// \param name the name property for the function.
+  /// \param paramCount the length property for the function, which
+  /// may not be the number of arguments the function is passed.
+  static Function createFromHostFunction(
+      Runtime& runtime,
+      const jsi::PropNameID& name,
+      unsigned int paramCount,
+      jsi::HostFunctionType func);
+
+  /// Calls the function with \c count \c args.  The \c this value of
+  /// the JS function will be undefined.
+  Value call(Runtime& runtime, const Value* args, size_t count) const;
+
+  /// Calls the function with a \c std::initializer_list of Value
+  /// arguments. The \c this value of the JS function will be
+  /// undefined.
+  Value call(Runtime& runtime, std::initializer_list<Value> args) const;
+
+  /// Calls the function with any number of arguments similarly to
+  /// Object::setProperty().  The \c this value of the JS function
+  /// will be undefined.
+  template <typename... Args>
+  Value call(Runtime& runtime, Args&&... args) const;
+
+  /// Calls the function with \c count \c args and \c jsThis value passed
+  /// as this value.
+  Value callWithThis(
+      Runtime& Runtime,
+      const Object& jsThis,
+      const Value* args,
+      size_t count) const;
+
+  /// Calls the function with a \c std::initializer_list of Value
+  /// arguments. The \c this value of the JS function will be
+  /// undefined.
+  Value callWithThis(
+      Runtime& runtime,
+      const Object& jsThis,
+      std::initializer_list<Value> args) const;
+
+  /// Calls the function with any number of arguments similarly to
+  /// Object::setProperty().  The \c this value of the JS function
+  /// will be undefined.
+  template <typename... Args>
+  Value callWithThis(Runtime& runtime, const Object& jsThis, Args&&... args)
+      const;
+
+  /// Calls the function as a constructor with \c count \c args. Equivalent
+  /// to calling `new Func` where `Func` is the js function reqresented by
+  /// this.
+  Value callAsConstructor(Runtime& runtime, const Value* args, size_t count)
+      const;
+
+  /// Same as above `callAsConstructor`, except use an initializer_list to
+  /// supply the arguments.
+  Value callAsConstructor(Runtime& runtime, std::initializer_list<Value> args)
+      const;
+
+  /// Same as above `callAsConstructor`, but automatically converts/wraps
+  /// any argument with a jsi Value.
+  template <typename... Args>
+  Value callAsConstructor(Runtime& runtime, Args&&... args) const;
+
+  /// Returns whether this was created with Function::createFromHostFunction.
+  /// If true then you can use getHostFunction to get the underlying
+  /// HostFunctionType.
+  bool isHostFunction(Runtime& runtime) const {
+    return runtime.isHostFunction(*this);
+  }
+
+  /// Returns the underlying HostFunctionType iff isHostFunction returns true
+  /// and asserts otherwise. You can use this to use std::function<>::target
+  /// to get the object that was passed to create the HostFunctionType.
+  ///
+  /// Note: The reference returned is borrowed from the JS object underlying
+  ///       \c this, and thus only lasts as long as the object underlying
+  ///       \c this does.
+  HostFunctionType& getHostFunction(Runtime& runtime) const {
+    assert(isHostFunction(runtime));
+    return runtime.getHostFunction(*this);
+  }
+
+ private:
+  friend class Object;
+  friend class Value;
+
+  Function(Runtime::PointerValue* value) : Object(value) {}
+};
+
+/// Represents any JS Value (undefined, null, boolean, number, symbol,
+/// string, or object).  Movable, or explicitly copyable (has no copy
+/// ctor).
+class Value {
+ public:
+  /// Default ctor creates an \c undefined JS value.
+  Value() : Value(UndefinedKind) {}
+
+  /// Creates a \c null JS value.
+  /* implicit */ Value(std::nullptr_t) : kind_(NullKind) {}
+
+  /// Creates a boolean JS value.
+  /* implicit */ Value(bool b) : Value(BooleanKind) {
+    data_.boolean = b;
+  }
+
+  /// Creates a number JS value.
+  /* implicit */ Value(double d) : Value(NumberKind) {
+    data_.number = d;
+  }
+
+  /// Creates a number JS value.
+  /* implicit */ Value(int i) : Value(NumberKind) {
+    data_.number = i;
+  }
+
+  /// Moves a Symbol, String, or Object rvalue into a new JS value.
+  template <typename T>
+  /* implicit */ Value(T&& other) : Value(kindOf(other)) {
+    static_assert(
+        std::is_base_of<Symbol, T>::value ||
+            std::is_base_of<String, T>::value ||
+            std::is_base_of<Object, T>::value,
+        "Value cannot be implicitly move-constructed from this type");
+    new (&data_.pointer) T(std::move(other));
+  }
+
+  /// Value("foo") will treat foo as a bool.  This makes doing that a
+  /// compile error.
+  template <typename T = void>
+  Value(const char*) {
+    static_assert(
+        !std::is_same<void, T>::value,
+        "Value cannot be constructed directly from const char*");
+  }
+
+  Value(Value&& value);
+
+  /// Copies a Symbol lvalue into a new JS value.
+  Value(Runtime& runtime, const Symbol& sym) : Value(SymbolKind) {
+    new (&data_.pointer) String(runtime.cloneSymbol(sym.ptr_));
+  }
+
+  /// Copies a String lvalue into a new JS value.
+  Value(Runtime& runtime, const String& str) : Value(StringKind) {
+    new (&data_.pointer) String(runtime.cloneString(str.ptr_));
+  }
+
+  /// Copies a Object lvalue into a new JS value.
+  Value(Runtime& runtime, const Object& obj) : Value(ObjectKind) {
+    new (&data_.pointer) Object(runtime.cloneObject(obj.ptr_));
+  }
+
+  /// Creates a JS value from another Value lvalue.
+  Value(Runtime& runtime, const Value& value);
+
+  /// Value(rt, "foo") will treat foo as a bool.  This makes doing
+  /// that a compile error.
+  template <typename T = void>
+  Value(Runtime&, const char*) {
+    static_assert(
+        !std::is_same<T, void>::value,
+        "Value cannot be constructed directly from const char*");
+  }
+
+  ~Value();
+  // \return the undefined \c Value.
+  static Value undefined() {
+    return Value();
+  }
+
+  // \return the null \c Value.
+  static Value null() {
+    return Value(nullptr);
+  }
+
+  // \return a \c Value created from a utf8-encoded JSON string.
+  static Value
+  createFromJsonUtf8(Runtime& runtime, const uint8_t* json, size_t length) {
+    return runtime.createValueFromJsonUtf8(json, length);
+  }
+
+  /// \return according to the SameValue algorithm see more here:
+  //  https://www.ecma-international.org/ecma-262/5.1/#sec-11.9.4
+  static bool strictEquals(Runtime& runtime, const Value& a, const Value& b);
+
+  Value& operator=(Value&& other) {
+    this->~Value();
+    new (this) Value(std::move(other));
+    return *this;
+  }
+
+  bool isUndefined() const {
+    return kind_ == UndefinedKind;
+  }
+
+  bool isNull() const {
+    return kind_ == NullKind;
+  }
+
+  bool isBool() const {
+    return kind_ == BooleanKind;
+  }
+
+  bool isNumber() const {
+    return kind_ == NumberKind;
+  }
+
+  bool isString() const {
+    return kind_ == StringKind;
+  }
+
+  bool isSymbol() const {
+    return kind_ == SymbolKind;
+  }
+
+  bool isObject() const {
+    return kind_ == ObjectKind;
+  }
+
+  /// \return the boolean value, or asserts if not a boolean.
+  bool getBool() const {
+    assert(isBool());
+    return data_.boolean;
+  }
+
+  /// \return the number value, or asserts if not a number.
+  double getNumber() const {
+    assert(isNumber());
+    return data_.number;
+  }
+
+  /// \return the number value, or throws JSIException if not a
+  /// number.
+  double asNumber() const;
+
+  /// \return the Symbol value, or asserts if not a symbol.
+  Symbol getSymbol(Runtime& runtime) const& {
+    assert(isSymbol());
+    return Symbol(runtime.cloneSymbol(data_.pointer.ptr_));
+  }
+
+  /// \return the Symbol value, or asserts if not a symbol.
+  /// Can be used on rvalue references to avoid cloning more symbols.
+  Symbol getSymbol(Runtime&) && {
+    assert(isSymbol());
+    auto ptr = data_.pointer.ptr_;
+    data_.pointer.ptr_ = nullptr;
+    return static_cast<Symbol>(ptr);
+  }
+
+  /// \return the Symbol value, or throws JSIException if not a
+  /// symbol
+  Symbol asSymbol(Runtime& runtime) const&;
+  Symbol asSymbol(Runtime& runtime) &&;
+
+  /// \return the String value, or asserts if not a string.
+  String getString(Runtime& runtime) const& {
+    assert(isString());
+    return String(runtime.cloneString(data_.pointer.ptr_));
+  }
+
+  /// \return the String value, or asserts if not a string.
+  /// Can be used on rvalue references to avoid cloning more strings.
+  String getString(Runtime&) && {
+    assert(isString());
+    auto ptr = data_.pointer.ptr_;
+    data_.pointer.ptr_ = nullptr;
+    return static_cast<String>(ptr);
+  }
+
+  /// \return the String value, or throws JSIException if not a
+  /// string.
+  String asString(Runtime& runtime) const&;
+  String asString(Runtime& runtime) &&;
+
+  /// \return the Object value, or asserts if not an object.
+  Object getObject(Runtime& runtime) const& {
+    assert(isObject());
+    return Object(runtime.cloneObject(data_.pointer.ptr_));
+  }
+
+  /// \return the Object value, or asserts if not an object.
+  /// Can be used on rvalue references to avoid cloning more objects.
+  Object getObject(Runtime&) && {
+    assert(isObject());
+    auto ptr = data_.pointer.ptr_;
+    data_.pointer.ptr_ = nullptr;
+    return static_cast<Object>(ptr);
+  }
+
+  /// \return the Object value, or throws JSIException if not an
+  /// object.
+  Object asObject(Runtime& runtime) const&;
+  Object asObject(Runtime& runtime) &&;
+
+  // \return a String like JS .toString() would do.
+  String toString(Runtime& runtime) const;
+
+ private:
+  friend class Runtime;
+
+  enum ValueKind {
+    UndefinedKind,
+    NullKind,
+    BooleanKind,
+    NumberKind,
+    SymbolKind,
+    StringKind,
+    ObjectKind,
+    PointerKind = SymbolKind,
+  };
+
+  union Data {
+    // Value's ctor and dtor will manage the lifecycle of the contained Data.
+    Data() {
+      static_assert(
+          sizeof(Data) == sizeof(uint64_t),
+          "Value data should fit in a 64-bit register");
+    }
+    ~Data() {}
+
+    // scalars
+    bool boolean;
+    double number;
+    // pointers
+    Pointer pointer; // Symbol, String, Object, Array, Function
+  };
+
+  Value(ValueKind kind) : kind_(kind) {}
+
+  constexpr static ValueKind kindOf(const Symbol&) {
+    return SymbolKind;
+  }
+  constexpr static ValueKind kindOf(const String&) {
+    return StringKind;
+  }
+  constexpr static ValueKind kindOf(const Object&) {
+    return ObjectKind;
+  }
+
+  ValueKind kind_;
+  Data data_;
+
+  // In the future: Value becomes NaN-boxed. See T40538354.
+};
+
+/// Not movable and not copyable RAII marker advising the underlying
+/// JavaScript VM to track resources allocated since creation until
+/// destruction so that they can be recycled eagerly when the Scope
+/// goes out of scope instead of floating in the air until the next
+/// garbage collection or any other delayed release occurs.
+///
+/// This API should be treated only as advice, implementations can
+/// choose to ignore the fact that Scopes are created or destroyed.
+///
+/// This class is an exception to the rule allowing destructors to be
+/// called without proper synchronization (see Runtime documentation).
+/// The whole point of this class is to enable all sorts of clean ups
+/// when the destructor is called and this proper synchronization is
+/// required at that time.
+///
+/// Instances of this class are intended to be created as automatic stack
+/// variables in which case destructor calls don't require any additional
+/// locking, provided that the lock (if any) is managed with RAII helpers.
+class Scope {
+ public:
+  explicit Scope(Runtime& rt) : rt_(rt), prv_(rt.pushScope()) {}
+  ~Scope() {
+    rt_.popScope(prv_);
+  };
+
+  Scope(const Scope&) = delete;
+  Scope(Scope&&) = delete;
+
+  Scope& operator=(const Scope&) = delete;
+  Scope& operator=(Scope&&) = delete;
+
+  template <typename F>
+  static auto callInNewScope(Runtime& rt, F f) -> decltype(f()) {
+    Scope s(rt);
+    return f();
+  }
+
+ private:
+  Runtime& rt_;
+  Runtime::ScopeState* prv_;
+};
+
+/// Base class for jsi exceptions
+class JSI_EXPORT JSIException : public std::exception {
+ protected:
+  JSIException(){};
+  JSIException(std::string what) : what_(std::move(what)){};
+
+ public:
+  virtual const char* what() const noexcept override {
+    return what_.c_str();
+  }
+
+  virtual ~JSIException();
+
+ protected:
+  std::string what_;
+};
+
+/// This exception will be thrown by API functions on errors not related to
+/// JavaScript execution.
+class JSI_EXPORT JSINativeException : public JSIException {
+ public:
+  JSINativeException(std::string what) : JSIException(std::move(what)) {}
+
+  virtual ~JSINativeException();
+};
+
+/// This exception will be thrown by API functions whenever a JS
+/// operation causes an exception as described by the spec, or as
+/// otherwise described.
+class JSI_EXPORT JSError : public JSIException {
+ public:
+  /// Creates a JSError referring to provided \c value
+  JSError(Runtime& r, Value&& value);
+
+  /// Creates a JSError referring to new \c Error instance capturing current
+  /// JavaScript stack. The error message property is set to given \c message.
+  JSError(Runtime& rt, std::string message);
+
+  /// Creates a JSError referring to new \c Error instance capturing current
+  /// JavaScript stack. The error message property is set to given \c message.
+  JSError(Runtime& rt, const char* message)
+      : JSError(rt, std::string(message)){};
+
+  /// Creates a JSError referring to a JavaScript Object having message and
+  /// stack properties set to provided values.
+  JSError(Runtime& rt, std::string message, std::string stack);
+
+  /// Creates a JSError referring to provided value and what string
+  /// set to provided message.  This argument order is a bit weird,
+  /// but necessary to avoid ambiguity with the above.
+  JSError(std::string what, Runtime& rt, Value&& value);
+
+  virtual ~JSError();
+
+  const std::string& getStack() const {
+    return stack_;
+  }
+
+  const std::string& getMessage() const {
+    return message_;
+  }
+
+  const jsi::Value& value() const {
+    assert(value_);
+    return *value_;
+  }
+
+ private:
+  // This initializes the value_ member and does some other
+  // validation, so it must be called by every branch through the
+  // constructors.
+  void setValue(Runtime& rt, Value&& value);
+
+  // This needs to be on the heap, because throw requires the object
+  // be copyable, and Value is not.
+  std::shared_ptr<jsi::Value> value_;
+  std::string message_;
+  std::string stack_;
+};
+
+} // namespace jsi
+} // namespace facebook
+
+#include "jsi-inl.h"
+

--- a/android/src/main/java/com/reactnativecommunity/webview/jsi/JsiException.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/jsi/JsiException.java
@@ -1,0 +1,7 @@
+package com.reactnativecommunity.webview.jsi;
+
+public class JsiException extends Exception {
+  public JsiException(String msg) {
+    super(msg);
+  }
+}

--- a/android/src/main/java/com/reactnativecommunity/webview/jsi/JsiJSError.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/jsi/JsiJSError.java
@@ -1,0 +1,13 @@
+package com.reactnativecommunity.webview.jsi;
+
+import com.reactnativecommunity.webview.jsi.JsiException;
+
+/**
+ * This exception means that JSI threw a JSError which is caused by an error being thrown
+ * by the javascript runtime
+ */
+public class JsiJSError extends JsiException {
+  public JsiJSError(String msg) {
+    super(msg);
+  }
+}

--- a/android/src/main/java/com/reactnativecommunity/webview/jsi/WebViewJsiInterface.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/jsi/WebViewJsiInterface.java
@@ -5,5 +5,13 @@ public class WebViewJsiInterface {
     System.loadLibrary("reactnativecommunity-webview");
   }
 
-  public native boolean onShouldStartLoadWithRequest(long javaScriptContextHolder, String key, String url, boolean loading, String title, boolean canGoBack, boolean canGoForward);
+  public native boolean onShouldStartLoadWithRequest(
+    long javaScriptContextHolder,
+    String key,
+    String url,
+    boolean loading,
+    String title,
+    boolean canGoBack,
+    boolean canGoForward)
+    throws JsiJSError, JsiException;
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/jsi/WebViewJsiInterface.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/jsi/WebViewJsiInterface.java
@@ -1,0 +1,9 @@
+package com.reactnativecommunity.webview.jsi;
+
+public class WebViewJsiInterface {
+  static {
+    System.loadLibrary("reactnativecommunity-webview");
+  }
+
+  public native boolean onShouldStartLoadWithRequest(long javaScriptContextHolder, String key, String url, boolean loading, String title, boolean canGoBack, boolean canGoForward);
+}

--- a/android/src/main/jni/Android.mk
+++ b/android/src/main/jni/Android.mk
@@ -1,0 +1,24 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+include $(LOCAL_PATH)/common.mk
+
+REACT_NATIVE := $(call find-node-module,$(LOCAL_PATH),react-native)
+
+LOCAL_CPPFLAGS := -std=c++17
+LOCAL_CPPFLAGS += -fexceptions
+LOCAL_CPPFLAGS += -frtti
+LOCAL_CPPFLAGS += -Wall
+LOCAL_CPPFLAGS += -Wextra
+LOCAL_CPPFLAGS += -Werror
+
+LOCAL_LDLIBS := -llog
+
+LOCAL_C_INCLUDES := $(REACT_NATIVE)/ReactCommon/jsi $(LOCAL_PATH)/../cpp
+
+LOCAL_SRC_FILES += $(REACT_NATIVE)/ReactCommon/jsi/jsi/jsi.cpp
+LOCAL_SRC_FILES += $(wildcard $(LOCAL_PATH)/../cpp/*.cpp)
+
+LOCAL_MODULE := reactnativecommunity-webview
+
+include $(BUILD_SHARED_LIBRARY)

--- a/android/src/main/jni/Android.mk
+++ b/android/src/main/jni/Android.mk
@@ -5,18 +5,20 @@ include $(LOCAL_PATH)/common.mk
 
 REACT_NATIVE := $(call find-node-module,$(LOCAL_PATH),react-native)
 
-LOCAL_CPPFLAGS := -std=c++17
+LOCAL_CPPFLAGS := -std=c++14
 LOCAL_CPPFLAGS += -fexceptions
 LOCAL_CPPFLAGS += -frtti
 LOCAL_CPPFLAGS += -Wall
 LOCAL_CPPFLAGS += -Wextra
 LOCAL_CPPFLAGS += -Werror
 
+LOCAL_DISABLE_FATAL_LINKER_WARNINGS := true
 LOCAL_LDLIBS := -llog
 
-LOCAL_C_INCLUDES := $(REACT_NATIVE)/ReactCommon/jsi $(LOCAL_PATH)/../cpp
+LOCAL_LDLIBS += -L$(BUILD_DIR)/_libraries/jni/$(APP_ABI)
 
-LOCAL_SRC_FILES += $(REACT_NATIVE)/ReactCommon/jsi/jsi/jsi.cpp
+LOCAL_LDLIBS += -ljscexecutor
+
 LOCAL_SRC_FILES += $(wildcard $(LOCAL_PATH)/../cpp/*.cpp)
 
 LOCAL_MODULE := reactnativecommunity-webview

--- a/android/src/main/jni/Application.mk
+++ b/android/src/main/jni/Application.mk
@@ -1,0 +1,2 @@
+APP_ABI := all
+APP_STL := c++_shared

--- a/android/src/main/jni/common.mk
+++ b/android/src/main/jni/common.mk
@@ -1,0 +1,29 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+##
+# Returns the absolute path to the specified npm package, searching from the
+# given base directory. This function uses Node's module resolution algorithm
+# searching "node_modules" in the base directory and its ancestors. If no
+# matching package is found, this function returns an empty string.
+#
+# The first argument to this function is the base directory from which to begin
+# searching. The second argument is the name of the npm package.
+#
+# Ex: $(call find-node-module,$(LOCAL_PATH),hermes-engine)
+###
+define find-node-module
+$(strip \
+	$(eval _base := $(strip $(1))) \
+	$(eval _package := $(strip $(2))) \
+	$(eval _candidate := $(abspath $(_base)/node_modules/$(_package))) \
+	$(if $(realpath $(_candidate)), \
+		$(_candidate), \
+		$(if $(_base), \
+				$(call find-node-module,$(patsubst %/,%,$(dir $(_base))),$(_package)) \
+		) \
+	) \
+)
+endef

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -41,15 +41,36 @@ If you wish to use CocoaPods and haven't set it up yet, please instead refer to 
 
 ### Android:
 
-Android - react-native-webview version <6:
-This module does not require any extra step after running the link command 🎉
+#### react-native-webview version < 6:
+This module does not require any extra step after running the link command. 🎉
 
-Android - react-native-webview version >=6.X.X:
+#### react-native-webview version >= 6.X.X:
 Please make sure AndroidX is enabled in your project by editting `android/gradle.properties` and adding 2 lines:
 
 ```
 android.useAndroidX=true
 android.enableJetifier=true
+```
+
+If you receive the following error when building:
+
+```
+More than one file was found with OS independent path 'lib/x86/libc++_shared.so'
+```
+
+Make sure that the following exists in your `android/app/build.gradle` file (which exists by default in react-native 0.62 projects):
+
+```
+android {
+  ...
+  packagingOptions {
+    pickFirst "lib/armeabi-v7a/libc++_shared.so"
+    pickFirst "lib/arm64-v8a/libc++_shared.so"
+    pickFirst "lib/x86/libc++_shared.so"
+    pickFirst "lib/x86_64/libc++_shared.so"
+  }
+  ...
+}
 ```
 
 For Android manual installation, please refer to [this article](https://engineering.brigad.co/demystifying-react-native-modules-linking-964399ec731b) where you can find detailed step on how to link any react-native project.

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -164,6 +164,14 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+
+    packagingOptions {
+       pickFirst "lib/armeabi-v7a/libc++_shared.so"
+       pickFirst "lib/arm64-v8a/libc++_shared.so"
+       pickFirst "lib/x86/libc++_shared.so"
+       pickFirst "lib/x86_64/libc++_shared.so"
+   }
+
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -235,6 +235,16 @@ export type OnShouldStartLoadWithRequest = (
   event: WebViewNavigation,
 ) => boolean;
 
+export interface WebViewJsiEvent {
+  url: string;
+  loading: boolean;
+  title: string;
+  canGoBack: boolean;
+  canGoForward: boolean;
+}
+
+export type JsiOnShouldStartLoadWithRequest = (arg0: WebViewJsiEvent) => boolean;
+
 export interface CommonNativeWebViewProps extends ViewProps {
   cacheEnabled?: boolean;
   incognito?: boolean;
@@ -282,6 +292,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   textZoom?: number;
   thirdPartyCookiesEnabled?: boolean;
   messagingModuleName?: string;
+  jsiOnShouldStartLoadWithRequestKey?: string;
   readonly urlPrefixesForDefaultIntent?: string[];
 }
 
@@ -721,7 +732,7 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    */
   geolocationEnabled?: boolean;
 
-  
+
   /**
    * Boolean that sets whether JavaScript running in the context of a file
    * scheme URL should be allowed to access content from other file scheme URLs.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

We (myself and @trcoffman) discovered a very interesting bug in our WebView app. Inside our app, there was a link that would HTTP redirect to a different origin, and then immediately manipulate history (to remove an authentication token from the URL and to navigate). This would cause the user to be stuck going back (you would go back and the history/location manipulation would happen again). The only way to get back was to tap the back button quickly multiple times in succession. Essentially, WebView added extra entries to the history stack that should not be there.

We tracked it down to the style of overriding loading. Essentially, every navigation on Android is suppressed in `shouldOverrideUrlLoading`, and an event is sent to JS to decide to navigate or not. If the navigation should happen, it causes a new page load. With this technique, the WebView seems to lose "context" about redirects and can improperly add to the history stack under the right conditions. Interestingly, this asynchronous approach also causes a lot of issues with debugging the WebView with the network inspector. Initiators are incorrect and the redirects aren't clearly exposed, since every load is a new page load.

The fix is to be able to synchronously decide in `shouldOverrideUrlLoading` whether to load or not. iOS does this approach by locking, sending an event, and waiting for the decision to come in asynchronously, and then unlocking. We tried a similar approach for Android but found it to deadlock (since it seems the WebView callbacks run on the same thread). The only way out was to use React Native's new JSI to be able to synchronously call into the JS runtime for the `onShouldStartLoadWithRequest` decision and have that result immediately for the WebView. I alluded to this [in earlier comments](https://github.com/react-native-community/react-native-webview/pull/991#issuecomment-580047127). We've known that doing this asynchronous style could be problematic, but never found a use case where it caused an issue until now. All said, this requires the addition of a native C++ module (JNI) to be built to be able to access the runtime using JSI.

The [Android docs warn against doing something very similar to what was being done](https://developer.android.com/reference/android/webkit/WebViewClient#shouldOverrideUrlLoading(android.webkit.WebView,%20android.webkit.WebResourceRequest)).

> Note: Do not call WebView#loadUrl(String) with the request's URL and then return true. This unnecessarily cancels the current load and starts a new load with the same URL. The correct way to continue loading a given URL is to simply return false, without calling WebView#loadUrl(String).

We found that with debugging, there is no JS runtime. This makes sense since it runs inside the Chrome process. As a fallback, the old asynchronous deny-then-load approach is kept when there is no JS runtime. This could allow for buggy behavior like we saw, but will allow users to debug their `onShouldStartLoadWithRequest`.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

Exploiting this behavior is non-trivial. It requires a link that redirects to a different origin, that then immediately manipulates browser history (`window.location` plus `history`). I've attached a video of behavior before our fix. Notice that tapping back doesn't go back to the original screen with the menu of links. It requires multiple taps to get back.

![ezgif-3-c932b0bd6e92](https://user-images.githubusercontent.com/1542454/85470088-68088500-b563-11ea-859f-afacf7094aa6.gif)

This is after our fix:

![ezgif-3-27d2f00c7109](https://user-images.githubusercontent.com/1542454/85470503-fc72e780-b563-11ea-9baf-1f220450a0f5.gif)

We've tested this fix quite a bit already in our app. I don't believe adding an example case makes sense.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

This requires react-native 0.60 or later for JSI to be in the expected location. We could not find any solid compatibility information within the repository, other than a peer dependency of `react-native >= 0.60`.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
