### PR TITLE
feat(android): WebView crash handling

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -927,6 +927,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         }
 
         WritableMap event = createWebViewEvent(webView, webView.getUrl());
+        event.putBoolean("didCrash", detail.didCrash());
 
         dispatchEvent(
           webView,

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -17,6 +17,7 @@ import android.os.Environment;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -27,6 +28,7 @@ import android.webkit.CookieManager;
 import android.webkit.DownloadListener;
 import android.webkit.GeolocationPermissions;
 import android.webkit.JavascriptInterface;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.SslErrorHandler;
 import android.webkit.PermissionRequest;
 import android.webkit.URLUtil;
@@ -69,6 +71,7 @@ import com.reactnativecommunity.webview.events.TopLoadingProgressEvent;
 import com.reactnativecommunity.webview.events.TopLoadingStartEvent;
 import com.reactnativecommunity.webview.events.TopMessageEvent;
 import com.reactnativecommunity.webview.events.TopShouldStartLoadWithRequestEvent;
+import com.reactnativecommunity.webview.events.TopCrashEvent;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -575,6 +578,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     export.put(TopShouldStartLoadWithRequestEvent.EVENT_NAME, MapBuilder.of("registrationName", "onShouldStartLoadWithRequest"));
     export.put(ScrollEventType.getJSEventName(ScrollEventType.SCROLL), MapBuilder.of("registrationName", "onScroll"));
     export.put(TopHttpErrorEvent.EVENT_NAME, MapBuilder.of("registrationName", "onHttpError"));
+    export.put(TopCrashEvent.EVENT_NAME, MapBuilder.of("registrationName", "onCrash"));
     return export;
   }
 
@@ -771,7 +775,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       mLastLoadFailed = false;
 
       RNCWebView reactWebView = (RNCWebView) webView;
-      reactWebView.callInjectedJavaScriptBeforeContentLoaded();       
+      reactWebView.callInjectedJavaScriptBeforeContentLoaded();
 
       dispatchEvent(
         webView,
@@ -828,11 +832,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           case SslError.SSL_UNTRUSTED:
             description = "The certificate authority is not trusted";
             break;
-          default: 
+          default:
             description = "Unknown SSL Error";
             break;
         }
-        
+
         description = descriptionPrefix + description;
 
         this.onReceivedError(
@@ -842,7 +846,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           failingUrl
         );
     }
-    
+
     @Override
     public void onReceivedError(
       WebView webView,
@@ -897,6 +901,33 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           webView,
           new TopHttpErrorEvent(webView.getId(), eventData));
       }
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    @Override
+    public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+        // WebViewClient.onRenderProcessGone was added in O.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return false;
+        }
+        super.onRenderProcessGone(view, detail);
+
+        if(detail.didCrash()){
+          Log.e("RNCWebViewManager", "The WebView rendering process crashed.");
+        }
+        else{
+          Log.w("RNCWebViewManager", "The WebView rendering process was killed by the system.");
+        }
+
+        WritableMap event = Arguments.createMap();
+        event.putBoolean("didCrash", detail.didCrash());
+        dispatchEvent(
+          view,
+          new TopCrashEvent(view.getId(), event)
+        );
+
+        // returning false would crash the app.
+        return true;
     }
 
     protected void emitFinishEvent(WebView webView, String url) {

--- a/android/src/main/java/com/reactnativecommunity/webview/events/TopCrashEvent.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/events/TopCrashEvent.kt
@@ -1,0 +1,25 @@
+package com.reactnativecommunity.webview.events
+
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.facebook.react.uimanager.events.RCTEventEmitter
+
+/**
+ * Event emitted when the WebView's process has crashed
+ */
+class TopCrashEvent(viewId: Int, private val mEventData: WritableMap) :
+  Event<TopCrashEvent>(viewId) {
+  companion object {
+    const val EVENT_NAME = "topCrash"
+  }
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun canCoalesce(): Boolean = false
+
+  override fun getCoalescingKey(): Short = 0
+
+  override fun dispatch(rctEventEmitter: RCTEventEmitter) =
+    rctEventEmitter.receiveEvent(viewTag, eventName, mEventData)
+
+}

--- a/android/src/main/java/com/reactnativecommunity/webview/events/TopRenderProcessGoneEvent.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/events/TopRenderProcessGoneEvent.kt
@@ -5,12 +5,13 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
 /**
- * Event emitted when the WebView's process has crashed
+ * Event emitted when the WebView's process has crashed or
+   was killed by the OS.
  */
-class TopCrashEvent(viewId: Int, private val mEventData: WritableMap) :
-  Event<TopCrashEvent>(viewId) {
+class TopRenderProcessGoneEvent(viewId: Int, private val mEventData: WritableMap) :
+  Event<TopRenderProcessGoneEvent>(viewId) {
   companion object {
-    const val EVENT_NAME = "topCrash"
+    const val EVENT_NAME = "topRenderProcessGone"
   }
 
   override fun getEventName(): String = EVENT_NAME

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -464,7 +464,7 @@ url
 Function that is invoked when the `WebView` process crashes or is killed by the OS on Android.
 
 > **_Note_**
-> Android API minimum level 26.
+> Android API minimum level 26. Android Only
 
 | Type     | Required |
 | -------- | -------- |
@@ -490,9 +490,6 @@ Function passed to `onCrash` is called with a SyntheticEvent wrapping a nativeEv
 ```
 didCrash
 ```
-
-> **_Note_**
-> Android only.
 
 ---
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -12,8 +12,8 @@ This document lays out the current public properties and methods for the React N
 - [`injectedJavaScriptBeforeContentLoadedForMainFrameOnly`](Reference.md#injectedjavascriptbeforecontentloadedformainframeonly)
 - [`mediaPlaybackRequiresUserAction`](Reference.md#mediaplaybackrequiresuseraction)
 - [`nativeConfig`](Reference.md#nativeconfig)
-- [`onCrash`](Reference.md#oncrash)
 - [`onError`](Reference.md#onerror)
+- [`onRenderProcessGone`](Reference.md#onRenderProcessGone)
 - [`onLoad`](Reference.md#onload)
 - [`onLoadEnd`](Reference.md#onloadend)
 - [`onLoadStart`](Reference.md#onloadstart)
@@ -459,7 +459,7 @@ url
 
 ---
 
-### `onCrash`
+### `onRenderProcessGone`[⬆](#props-index)<!-- Link generated with jump2header -->
 
 Function that is invoked when the `WebView` process crashes or is killed by the OS on Android.
 
@@ -475,7 +475,7 @@ Example:
 ```jsx
 <WebView
   source={{ uri: 'https://reactnative.dev' }}
-  onCrash={syntheticEvent => {
+  onRenderProcessGone={syntheticEvent => {
     const { nativeEvent } = syntheticEvent;
     console.warn(
       'WebView Crashed: ',
@@ -485,7 +485,7 @@ Example:
 />
 ```
 
-Function passed to `onCrash` is called with a SyntheticEvent wrapping a nativeEvent with these properties:
+Function passed to `onRenderProcessGone` is called with a SyntheticEvent wrapping a nativeEvent with these properties:
 
 ```
 didCrash

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -12,6 +12,7 @@ This document lays out the current public properties and methods for the React N
 - [`injectedJavaScriptBeforeContentLoadedForMainFrameOnly`](Reference.md#injectedjavascriptbeforecontentloadedformainframeonly)
 - [`mediaPlaybackRequiresUserAction`](Reference.md#mediaplaybackrequiresuseraction)
 - [`nativeConfig`](Reference.md#nativeconfig)
+- [`onCrash`](Reference.md#oncrash)
 - [`onError`](Reference.md#onerror)
 - [`onLoad`](Reference.md#onload)
 - [`onLoadEnd`](Reference.md#onloadend)
@@ -455,6 +456,43 @@ url
 
 > **_Note_**
 > Description is only used on Android
+
+---
+
+### `onCrash`
+
+Function that is invoked when the `WebView` process crashes or is killed by the OS on Android.
+
+> **_Note_**
+> Android API minimum level 26.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+Example:
+
+```jsx
+<WebView
+  source={{ uri: 'https://reactnative.dev' }}
+  onCrash={syntheticEvent => {
+    const { nativeEvent } = syntheticEvent;
+    console.warn(
+      'WebView Crashed: ',
+      nativeEvent.didCrash,
+    );
+  }}
+/>
+```
+
+Function passed to `onCrash` is called with a SyntheticEvent wrapping a nativeEvent with these properties:
+
+```
+didCrash
+```
+
+> **_Note_**
+> Android only.
 
 ---
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -21,7 +21,7 @@ import {
   defaultRenderLoading,
 } from './WebViewShared';
 import {
-  WebViewCrashEvent,
+  WebViewRenderProcessGoneEvent,
   WebViewErrorEvent,
   WebViewHttpErrorEvent,
   WebViewMessageEvent,
@@ -229,10 +229,10 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     }
   }
 
-  onCrash = (event: WebViewCrashEvent) => {
-    const { onCrash } = this.props;
-    if (onCrash) {
-      onCrash(event);
+  onRenderProcessGone = (event: WebViewRenderProcessGoneEvent) => {
+    const { onRenderProcessGone } = this.props;
+    if (onRenderProcessGone) {
+      onRenderProcessGone(event);
     }
   }
 
@@ -355,7 +355,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
         onLoadingProgress={this.onLoadingProgress}
         onLoadingStart={this.onLoadingStart}
         onHttpError={this.onHttpError}
-        onCrash={this.onCrash}
+        onRenderProcessGone={this.onRenderProcessGone}
         onMessage={this.onMessage}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
         ref={this.webViewRef}

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -21,6 +21,7 @@ import {
   defaultRenderLoading,
 } from './WebViewShared';
 import {
+  WebViewCrashEvent,
   WebViewErrorEvent,
   WebViewHttpErrorEvent,
   WebViewMessageEvent,
@@ -228,6 +229,13 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     }
   }
 
+  onCrash = (event: WebViewCrashEvent) => {
+    const { onCrash } = this.props;
+    if (onCrash) {
+      onCrash(event);
+    }
+  }
+
   onLoadingFinish = (event: WebViewNavigationEvent) => {
     const { onLoad, onLoadEnd } = this.props;
     const { nativeEvent: { url } } = event;
@@ -347,6 +355,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
         onLoadingProgress={this.onLoadingProgress}
         onLoadingStart={this.onLoadingStart}
         onHttpError={this.onHttpError}
+        onCrash={this.onCrash}
         onMessage={this.onMessage}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
         ref={this.webViewRef}

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -137,6 +137,10 @@ export interface WebViewHttpError extends WebViewNativeEvent {
   statusCode: number;
 }
 
+export interface WebViewCrashError extends WebViewNativeEvent {
+  didCrash: boolean;
+}
+
 export type WebViewEvent = NativeSyntheticEvent<WebViewNativeEvent>;
 
 export type WebViewProgressEvent = NativeSyntheticEvent<
@@ -154,6 +158,8 @@ export type WebViewErrorEvent = NativeSyntheticEvent<WebViewError>;
 export type WebViewTerminatedEvent = NativeSyntheticEvent<WebViewNativeEvent>;
 
 export type WebViewHttpErrorEvent = NativeSyntheticEvent<WebViewHttpError>;
+
+export type WebViewCrashEvent = NativeSyntheticEvent<WebViewCrashError>;
 
 export type DataDetectorTypes =
   | 'phoneNumber'
@@ -277,6 +283,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   javaScriptEnabled?: boolean;
   mixedContentMode?: 'never' | 'always' | 'compatibility';
   onContentSizeChange?: (event: WebViewEvent) => void;
+  onCrash?: (event: WebViewCrashEvent) => void;
   overScrollMode?: OverScrollModeType;
   saveFormDataDisabled?: boolean;
   textZoom?: number;
@@ -721,7 +728,7 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    */
   geolocationEnabled?: boolean;
 
-  
+
   /**
    * Boolean that sets whether JavaScript running in the context of a file
    * scheme URL should be allowed to access content from other file scheme URLs.
@@ -879,6 +886,12 @@ export interface WebViewSharedProps extends ViewProps {
    * Works on iOS and Android (minimum API level 23).
    */
   onHttpError?: (event: WebViewHttpErrorEvent) => void;
+
+  /**
+   * Function that is invoked when the `WebView` process crashes or is killed.
+   * Works on Android (minimum API level 26).
+   */
+  onCrash?: (event: WebViewCrashError) => void;
 
   /**
    * Function that is invoked when the `WebView` loading starts or ends.

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -137,7 +137,7 @@ export interface WebViewHttpError extends WebViewNativeEvent {
   statusCode: number;
 }
 
-export interface WebViewCrashError extends WebViewNativeEvent {
+export interface WebViewCrashError {
   didCrash: boolean;
 }
 
@@ -691,6 +691,12 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
   onContentSizeChange?: (event: WebViewEvent) => void;
 
   /**
+   * Function that is invoked when the `WebView` process crashes or is killed.
+   * Works on Android (minimum API level 26).
+   */
+  onCrash?: (event: WebViewCrashEvent) => void;
+
+  /**
    * https://developer.android.com/reference/android/webkit/WebSettings.html#setCacheMode(int)
    * Set the cacheMode. Possible values are:
    *
@@ -886,12 +892,6 @@ export interface WebViewSharedProps extends ViewProps {
    * Works on iOS and Android (minimum API level 23).
    */
   onHttpError?: (event: WebViewHttpErrorEvent) => void;
-
-  /**
-   * Function that is invoked when the `WebView` process crashes or is killed.
-   * Works on Android (minimum API level 26).
-   */
-  onCrash?: (event: WebViewCrashError) => void;
 
   /**
    * Function that is invoked when the `WebView` loading starts or ends.

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -137,7 +137,7 @@ export interface WebViewHttpError extends WebViewNativeEvent {
   statusCode: number;
 }
 
-export interface WebViewCrashError {
+export interface WebViewRenderProcessGoneDetail {
   didCrash: boolean;
 }
 
@@ -159,7 +159,7 @@ export type WebViewTerminatedEvent = NativeSyntheticEvent<WebViewNativeEvent>;
 
 export type WebViewHttpErrorEvent = NativeSyntheticEvent<WebViewHttpError>;
 
-export type WebViewCrashEvent = NativeSyntheticEvent<WebViewCrashError>;
+export type WebViewRenderProcessGoneEvent = NativeSyntheticEvent<WebViewRenderProcessGoneDetail>;
 
 export type DataDetectorTypes =
   | 'phoneNumber'
@@ -283,7 +283,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   javaScriptEnabled?: boolean;
   mixedContentMode?: 'never' | 'always' | 'compatibility';
   onContentSizeChange?: (event: WebViewEvent) => void;
-  onCrash?: (event: WebViewCrashEvent) => void;
+  onRenderProcessGone?: (event: WebViewRenderProcessGoneEvent) => void;
   overScrollMode?: OverScrollModeType;
   saveFormDataDisabled?: boolean;
   textZoom?: number;
@@ -691,10 +691,10 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
   onContentSizeChange?: (event: WebViewEvent) => void;
 
   /**
-   * Function that is invoked when the `WebView` process crashes or is killed.
-   * Works on Android (minimum API level 26).
+   * Function that is invoked when the `WebView` process crashes or is killed by the OS.
+   * Works only on Android (minimum API level 26).
    */
-  onCrash?: (event: WebViewCrashEvent) => void;
+  onRenderProcessGone?: (event: WebViewRenderProcessGoneEvent) => void;
 
   /**
    * https://developer.android.com/reference/android/webkit/WebSettings.html#setCacheMode(int)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

On Android, the WebView process may get killed/crash. When this happens, if not handled appropriately, the whole app gets terminated in a quite brutal way (not even error reporting frameworks seemed to report this crash).

The fix: implement a handler for `onRenderProcessGone` (SDK >= 26) and return `true`.

The implementation also adds a new `onCrash` event so a webview crash can be handled on user land.

TODO: Review implementation for iOS, although it is most likely not needed.

## Test Plan
Tested on Motorola G5 and Google Pixel 2
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Device / simulator

### What are the steps to reproduce (after prerequisites)?
Test a webview that may run out of memory or render a extremely large image.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
