### PR TITLE
Add bouncesZoom prop for iOS + macOS

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -39,6 +39,7 @@
 @property (nonatomic, assign) CGFloat decelerationRate;
 @property (nonatomic, assign) BOOL allowsInlineMediaPlayback;
 @property (nonatomic, assign) BOOL bounces;
+@property (nonatomic, assign) BOOL bouncesZoom;
 @property (nonatomic, assign) BOOL mediaPlaybackRequiresUserAction;
 #if WEBKIT_IOS_10_APIS_AVAILABLE
 @property (nonatomic, assign) WKDataDetectorTypes dataDetectorTypes;

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -120,6 +120,7 @@ static NSDictionary* customCertificatesForHost;
     super.backgroundColor = [RCTUIColor clearColor];
     #endif // !TARGET_OS_OSX
     _bounces = YES;
+    _bouncesZoom = YES;
     _scrollEnabled = YES;
     _showsHorizontalScrollIndicator = YES;
     _showsVerticalScrollIndicator = YES;
@@ -146,7 +147,7 @@ static NSDictionary* customCertificatesForHost;
     selector:@selector(appDidBecomeActive)
         name:UIApplicationDidBecomeActiveNotification
       object:nil];
-
+    
     [[NSNotificationCenter defaultCenter]addObserver:self
     selector:@selector(appWillResignActive)
         name:UIApplicationWillResignActiveNotification
@@ -174,7 +175,7 @@ static NSDictionary* customCertificatesForHost;
                                                selector:@selector(hideFullScreenVideoStatusBars)
                                                    name:UIWindowDidBecomeHiddenNotification
                                                  object:nil];
-
+      
   }
 #endif // !TARGET_OS_OSX
   return self;
@@ -246,7 +247,7 @@ static NSDictionary* customCertificatesForHost;
   if (_applicationNameForUserAgent) {
       wkWebViewConfig.applicationNameForUserAgent = [NSString stringWithFormat:@"%@ %@", wkWebViewConfig.applicationNameForUserAgent, _applicationNameForUserAgent];
   }
-
+  
   return wkWebViewConfig;
 }
 
@@ -270,6 +271,7 @@ static NSDictionary* customCertificatesForHost;
     _webView.scrollView.scrollEnabled = _scrollEnabled;
     _webView.scrollView.pagingEnabled = _pagingEnabled;
     _webView.scrollView.bounces = _bounces;
+    _webView.scrollView.bouncesZoom = _bouncesZoom;
     _webView.scrollView.showsHorizontalScrollIndicator = _showsHorizontalScrollIndicator;
     _webView.scrollView.showsVerticalScrollIndicator = _showsVerticalScrollIndicator;
     _webView.scrollView.directionalLockEnabled = _directionalLockEnabled;
@@ -1110,7 +1112,7 @@ static NSDictionary* customCertificatesForHost;
   if (_ignoreSilentHardwareSwitch) {
     [self forceIgnoreSilentHardwareSwitch:true];
   }
-
+    
   if (_onLoadingFinish) {
     _onLoadingFinish([self baseEvent]);
   }
@@ -1158,16 +1160,21 @@ static NSDictionary* customCertificatesForHost;
   _bounces = bounces;
   _webView.scrollView.bounces = bounces;
 }
+- (void)setBouncesZoom:(BOOL)bouncesZoom
+{
+  _bouncesZoom = bouncesZoom;
+  _webView.scrollView.bouncesZoom = bouncesZoom;
+}
 #endif // !TARGET_OS_OSX
 
 
 - (void)setInjectedJavaScript:(NSString *)source {
   _injectedJavaScript = source;
-
+  
   self.atEndScript = source == nil ? nil : [[WKUserScript alloc] initWithSource:source
       injectionTime:WKUserScriptInjectionTimeAtDocumentEnd
     forMainFrameOnly:_injectedJavaScriptForMainFrameOnly];
-
+  
   if(_webView != nil){
     [self resetupScripts:_webView.configuration];
   }
@@ -1175,11 +1182,11 @@ static NSDictionary* customCertificatesForHost;
 
 - (void)setInjectedJavaScriptBeforeContentLoaded:(NSString *)source {
   _injectedJavaScriptBeforeContentLoaded = source;
-
+  
   self.atStartScript = source == nil ? nil : [[WKUserScript alloc] initWithSource:source
        injectionTime:WKUserScriptInjectionTimeAtDocumentStart
     forMainFrameOnly:_injectedJavaScriptBeforeContentLoadedForMainFrameOnly];
-
+  
   if(_webView != nil){
     [self resetupScripts:_webView.configuration];
   }
@@ -1197,7 +1204,7 @@ static NSDictionary* customCertificatesForHost;
 
 - (void)setMessagingEnabled:(BOOL)messagingEnabled {
   _messagingEnabled = messagingEnabled;
-
+  
   self.postMessageScript = _messagingEnabled ?
   [
    [WKUserScript alloc]
@@ -1217,7 +1224,7 @@ static NSDictionary* customCertificatesForHost;
    forMainFrameOnly:YES
    ] :
   nil;
-
+  
   if(_webView != nil){
     [self resetupScripts:_webView.configuration];
   }
@@ -1226,7 +1233,7 @@ static NSDictionary* customCertificatesForHost;
 - (void)resetupScripts:(WKWebViewConfiguration *)wkWebViewConfig {
   [wkWebViewConfig.userContentController removeAllUserScripts];
   [wkWebViewConfig.userContentController removeScriptMessageHandlerForName:MessageHandlerName];
-
+  
   NSString *html5HistoryAPIShimSource = [NSString stringWithFormat:
     @"(function(history) {\n"
     "  function notify(type) {\n"
@@ -1249,7 +1256,7 @@ static NSDictionary* customCertificatesForHost;
   ];
   WKUserScript *script = [[WKUserScript alloc] initWithSource:html5HistoryAPIShimSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
   [wkWebViewConfig.userContentController addUserScript:script];
-
+  
   if(_sharedCookiesEnabled) {
     // More info to sending cookies with WKWebView
     // https://stackoverflow.com/questions/26573137/can-i-set-the-cookies-to-be-used-by-a-wkwebview/26577303#26577303
@@ -1311,7 +1318,7 @@ static NSDictionary* customCertificatesForHost;
       [wkWebViewConfig.userContentController addUserScript:cookieInScript];
     }
   }
-
+  
   if(_messagingEnabled){
     if (self.postMessageScript){
       [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -93,6 +93,10 @@ RCT_CUSTOM_VIEW_PROPERTY(bounces, BOOL, RNCWebView) {
   view.bounces = json == nil ? true : [RCTConvert BOOL: json];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(bouncesZoom, BOOL, RNCWebView) {
+  view.bouncesZoom = json == nil ? true : [RCTConvert BOOL: json];
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(useSharedProcessPool, BOOL, RNCWebView) {
   view.useSharedProcessPool = json == nil ? true : [RCTConvert BOOL: json];
 }

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -41,6 +41,7 @@ This document lays out the current public properties and methods for the React N
 - [`allowsFullscreenVideo`](Reference.md#allowsfullscreenvideo)
 - [`allowsInlineMediaPlayback`](Reference.md#allowsinlinemediaplayback)
 - [`bounces`](Reference.md#bounces)
+- [`bouncesZoom`](Reference.md#bouncesZoom)
 - [`overScrollMode`](Reference.md#overscrollmode)
 - [`contentInset`](Reference.md#contentinset)
 - [`contentInsetAdjustmentBehavior`](Reference.md#contentInsetAdjustmentBehavior)
@@ -833,6 +834,16 @@ Boolean that determines whether HTML5 videos play inline or use the native full-
 ### `bounces`
 
 Boolean value that determines whether the web view bounces when it reaches the edge of the content. The default value is `true`.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | iOS      |
+
+---
+
+### `bouncesZoom`
+
+Boolean value that determines whether the web view bounces when it reaches the minimum or maximum zoom scale. The default value is `true`.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -299,6 +299,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   allowsLinkPreview?: boolean;
   automaticallyAdjustContentInsets?: boolean;
   bounces?: boolean;
+  bouncesZoom?: boolean;
   contentInset?: ContentInsetProp;
   contentInsetAdjustmentBehavior?: ContentInsetAdjustmentBehavior;
   readonly dataDetectorTypes?: DataDetectorTypes | DataDetectorTypes[];
@@ -321,6 +322,7 @@ export interface MacOSNativeWebViewProps extends CommonNativeWebViewProps {
   allowsLinkPreview?: boolean;
   automaticallyAdjustContentInsets?: boolean;
   bounces?: boolean;
+  bouncesZoom?: boolean;
   contentInset?: ContentInsetProp;
   contentInsetAdjustmentBehavior?: ContentInsetAdjustmentBehavior;
   directionalLockEnabled?: boolean;
@@ -347,6 +349,13 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   bounces?: boolean;
+
+  /**
+   * Boolean value that determines whether the web view bounces
+   * when it reaches the minimum or maximum zoom scale. The default value is `true`.
+   * @platform ios
+   */
+  bouncesZoom?: boolean;
 
   /**
    * A floating-point number that determines how quickly the scroll view
@@ -554,6 +563,13 @@ export interface MacOSWebViewProps extends WebViewSharedProps {
    * @platform macos
    */
   bounces?: boolean;
+
+  /**
+   * Boolean value that determines whether the web view bounces
+   * when it reaches the minimum or maximum zoom scale. The default value is `true`.
+   * @platform macos
+   */
+  bouncesZoom?: boolean;  
 
   /**
    * Boolean value that determines whether scrolling is enabled in the


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
Following issue #1484 I've added the bouncesZoom prop for iOS and macOS.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Using https://github.com/react-native-community/react-native-webview/blob/master/example/examples/Scrolling.tsx , change user-scalable=no to user-scalable=yes and add minimum-scale=0.8, maximum-scale=2.0
Set property bouncesZoom on the Webview to false.
Pinch to zoom in/out and observe the zooming causes a "bounce" effect/animation. 
Set the property bouncesZoom to true and observe it no longer bounces zoom.
                
### What's required for testing (prerequisites)?
See above.

### What are the steps to reproduce (after prerequisites)?
Run the example above.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
