### PR TITLE
Disable force overlapping rendering for Android 9 or higher

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -164,7 +164,13 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   }
 
   protected RNCWebView createRNCWebViewInstance(ThemedReactContext reactContext) {
-    return new RNCWebView(reactContext);
+    RNCWebView webView = new RNCWebView(reactContext);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      webView.forceHasOverlappingRendering(false);
+    }
+
+    return webView;
   }
 
   @Override


### PR DESCRIPTION
# Summary


Following issue #906 I've added the fix to avoid IllegalStateException android.os.MessageQueue exception.

On some devices e.g. Samsung Galaxy J4+, J6+ WebView crashes when hardware acceleration is enabled. It may happen only when WebView is wrapped by ScrollView and exceeds max height supported by GPU. Then exception IllegalStateException android.os.MessageQueue is thrown. Unfortunately, disabling hardware acceleration does not resolve the issue as expected (e.g. displaying videos does not work anymore). To resolve this issue I added a fix, which disables overlapping rendering. In result, WebView does not crash with ScrollView.


## Test Plan
Tested on Samsung Galaxy J6+.

## What's required for testing (prerequisites)?
It can be reproduced only on some devices (from my logs) :

- Samsung Galaxy J4+
- Samsung Galaxy J6+
- Samsung Galaxy J4 Plus 2018
- Samsung Galaxy Tab A 8.0 2017
- Samsung Galaxy Tab A 8.0 2017
- Nokia 2.1

## What are the steps to reproduce (after prerequisites)?

To reproduce this issue we need WebView with large content wrapped by ScrollView. Without this fix, app crashes with exception.

`  <ScrollView
                contentContainerStyle={{ height: 4000 }} // it causes WebView crash 
            >
                <WebView
                    style={{ height: 4000, opacity: 0.99, flex: 1 }}
                    androidForceHasOverlappingRendering={false}
                    source={{ html: '<p>Large html content</p>' }}
                />
            </ScrollView>
`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |      ❌     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
