### PR TITLE
Add a debugging note

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -15,11 +15,13 @@ It's possible to debug WebView contents in the iOS simulator or on a device usin
 3. Safari -> Develop -> [device name] -> [app name] -> [url - title]
 4. You can now debug the WebView contents just as you would on the web
 
-##### Note:
+##### Notes:
 
 When debugging on device you must enable Web Inspector in your device settings:
 
 Settings -> Safari -> Advanced -> Web Inspector
+
+Also, if you don't see your device in the Develop menu, and you started Safari before you started your simulator, try restarting Safari.
 
 ### Android & Chrome
 


### PR DESCRIPTION
# Summary

I do `react-native-webview` debugging pretty infrequently, so when I don't see my simulator in the Develop menu, I forget to try restarting Safari. Twice now it's been the fix, and if this PR gets merged I won't waste time trying to figure this out next time!

## Test Plan

Worked on my machine :-)

### What's required for testing (prerequisites)?

Nothing - just a doc update

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md` (well, in `Debugging.md`)
- [X] I mentioned this change in `CHANGELOG.md`(hmm, I don't see that file, and the change history in `README.md` is breaking changes only, which this isn't)
- [X] I updated the typed files (TS and Flow) (no changes needed)
- [X] I added a sample use of the API in the example project (`example/App.js`) (N/A since this is just a doc update)
