### PR TITLE
fix: add `Referer` header for Android `loadUrl()` command

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -640,7 +640,18 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           throw new RuntimeException("Arguments for loading an url are null!");
         }
         ((RNCWebView) root).progressChangedFilter.setWaitingForCommandLoadUrl(false);
-        root.loadUrl(args.getString(0));
+        String url = args.getString(0);
+        HashMap<String, String> headerMap = new HashMap<>();
+        // try to add referer header when navigate to a new url
+        String refererUrl = ((RNCWebView) root).progressChangedFilter.getRefererUrl();
+        if (refererUrl != null &&
+          // "no-referrer-when-downgrade" policy is the default behavior
+          // https://www.w3.org/TR/referrer-policy/#referrer-policy-no-referrer-when-downgrade
+          (!refererUrl.startsWith("https://") || url.startsWith("https://"))
+        ) {
+          headerMap.put("referer", refererUrl);
+        }
+        root.loadUrl(url, headerMap);
         break;
       case COMMAND_FOCUS:
         root.requestFocus();
@@ -771,7 +782,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       mLastLoadFailed = false;
 
       RNCWebView reactWebView = (RNCWebView) webView;
-      reactWebView.callInjectedJavaScriptBeforeContentLoaded();       
+      reactWebView.callInjectedJavaScriptBeforeContentLoaded();
 
       dispatchEvent(
         webView,
@@ -782,13 +793,13 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
-      progressChangedFilter.setWaitingForCommandLoadUrl(true);
-      dispatchEvent(
-        view,
-        new TopShouldStartLoadWithRequestEvent(
-          view.getId(),
-          createWebViewEvent(view, url)));
-      return true;
+      // cannot tell if it's a server side redirect or not on Android M 6.0 and below,
+      // always set it to false let referer being updated.
+      // it may cause issue on some cases with multiple consecutive redirects:
+      // https://github.com/react-native-community/react-native-webview/pull/1200#issuecomment-650983886
+      // but it's already the best try to get the other more common cases work.
+      // There is a js side workaround to address such multiple consecutive redirects on Android 6.0 and below.
+      return this.shouldOverrideUrlLoading(view, url, false);
     }
 
 
@@ -796,7 +807,32 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
       final String url = request.getUrl().toString();
-      return this.shouldOverrideUrlLoading(view, url);
+      final boolean isRedirect = request.isRedirect();
+      return this.shouldOverrideUrlLoading(view, url, isRedirect);
+    }
+
+    protected boolean shouldOverrideUrlLoading(WebView view, String url, boolean isRedirect) {
+      progressChangedFilter.setWaitingForCommandLoadUrl(true);
+      // Update referer url if it's not a server-side redirect or no previous referer url
+      if (!isRedirect || progressChangedFilter.getRefererUrl() == null) {
+        progressChangedFilter.setRefererUrl(view.getUrl());
+      }
+
+      WritableMap event = createWebViewEvent(view, url);
+      // put referer into event params to let client to choose whether or not to include in in custom headers
+      // check out more details about set custom headers at:
+      // https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#setting-custom-headers
+      String refererUrl = progressChangedFilter.getRefererUrl();
+      if (refererUrl != null) {
+        event.putString("referer", refererUrl);
+      }
+
+      dispatchEvent(
+        view,
+        new TopShouldStartLoadWithRequestEvent(
+          view.getId(),
+          event));
+      return true;
     }
 
     @Override
@@ -828,11 +864,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           case SslError.SSL_UNTRUSTED:
             description = "The certificate authority is not trusted";
             break;
-          default: 
+          default:
             description = "Unknown SSL Error";
             break;
         }
-        
+
         description = descriptionPrefix + description;
 
         this.onReceivedError(
@@ -842,7 +878,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           failingUrl
         );
     }
-    
+
     @Override
     public void onReceivedError(
       WebView webView,
@@ -1357,6 +1393,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     protected static class ProgressChangedFilter {
       private boolean waitingForCommandLoadUrl = false;
+      private @Nullable String refererUrl = null;
 
       public void setWaitingForCommandLoadUrl(boolean isWaiting) {
         waitingForCommandLoadUrl = isWaiting;
@@ -1365,6 +1402,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       public boolean isWaitingForCommandLoadUrl() {
         return waitingForCommandLoadUrl;
       }
+
+      public void setRefererUrl(String url) {
+        refererUrl = url;
+      }
+
+      public String getRefererUrl() { return refererUrl; }
     }
   }
 }

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -937,6 +937,10 @@ static NSDictionary* customCertificatesForHost;
       @"mainDocumentURL": (request.mainDocumentURL).absoluteString,
       @"navigationType": navigationTypes[@(navigationType)]
     }];
+    NSString *referer = [request valueForHTTPHeaderField:@"referer"];
+    if (referer) {
+      [event setObject:referer forKey:@"referer"];
+    }
     if (![self.delegate webView:self
       shouldStartLoadForRequest:event
                    withCallback:_onShouldStartLoadWithRequest]) {

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -647,6 +647,7 @@ canGoForward
 lockIdentifier
 mainDocumentURL (iOS only)
 navigationType
+referer
 ```
 
 ---

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -111,6 +111,7 @@ export interface WebViewNavigation extends WebViewNativeEvent {
     | 'formresubmit'
     | 'other';
   mainDocumentURL?: string;
+  referer?: string;
 }
 
 export interface FileDownload {


### PR DESCRIPTION
- add "Referer" header in Android `loadUrl()` command to fix issues that caused by its absense
- expose `referer` field to `onShouldStartLoadWithRequest` event to let client include it into custom headers when necessary

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This is an update of previous PR #1200 

For redirected url loading, current behehavior is we always return true to prevent it being loaded in shouldOverrideUrlLoading, with TopShouldStartLoadWithRequestEvent being sent to RN and then call webview.loadUrl() if such redirect loading was approved on RN.
However, the Referer header would be different between webview.loadUrl and return false in shouldOverrideUrlLoading. It might cause redirect issues ( #1073, #1434 ) 

The proposed solution here is to:
1. (Android) keep a referer url when navigation happens and use it as referer header as default behavior.
2. (Both Android & iOS) include the `referer` along with other parameters in `onShouldStartLoadWithRequest` to let js land have a chance to deal with combining referer and other custom headers

Regarding the multiple consecutive redirects case described in #1434 (details: https://github.com/react-native-community/react-native-webview/pull/1200#issuecomment-650983886). It may still have issue on Android 6.0 and below with this fix. Since `boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request)` only works on Android N and above, and we cannot tell if current url loading request is server redirect or not without the `WebResourceRequest` - cannot decide whether the referer header need to be updated or not.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
1. test loading https://s.click.taobao.com/fj2tptv (url from #1073 )
2. test loading https://mijn.uwv.nl/ and click the leftmost button labeled 'DigiD Inloggen' ( #1434) on Android 7+

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
