### PR TITLE
Convert ContentInsetAdjustmentBehavior from an enum back to a string union type

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -285,12 +285,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   readonly urlPrefixesForDefaultIntent?: string[];
 }
 
-export enum ContentInsetAdjustmentBehavior {
-  automatic = 'automatic',
-  scrollableAxes = 'scrollableAxes',
-  never = 'never',
-  always = 'always'
-};
+export declare type ContentInsetAdjustmentBehavior = 'automatic' | 'scrollableAxes' | 'never' | 'always';
 
 export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   allowingReadAccessToURL?: string;


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

`ContentInsetAdjustmentBehavior` was originally added as a string union type (https://github.com/react-native-community/react-native-webview/pull/730). The change to support MacOS (https://github.com/react-native-community/react-native-webview/pull/1164) replaced it with an enum (https://github.com/react-native-community/react-native-webview/pull/1164/files#diff-bad447a30759e328812e9bae6798621cR269), which was a breaking change, especially as the enum was not exported from the main library. Exporting the enum would probably also help, but since this was the only enum and the rest of `react-native-webview` uses string unions instead, it seems best to revert it to a string union.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The `ContentInsetAdjustmentBehavior` prop can now once again be simply set to a string value like "always." Before this change the property required using a value of the `ContentInsetAdjustmentBehavior` enum, which was difficult to set since that enum was not exported by `react-native-webview`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅  |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md` (uh, **this file doesn't exist?**)
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
