### PR TITLE
fix(types): Add missing applicationNameForUserAgent type in WebViewSharedProps

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -973,4 +973,9 @@ export interface WebViewSharedProps extends ViewProps {
    * Should caching be enabled. Default is true.
    */
   cacheEnabled?: boolean;
+
+  /**
+   * Append to the existing user-agent. Overridden if `userAgent` is set.
+   */
+  applicationNameForUserAgent?: string;
 }


### PR DESCRIPTION
**NOTE**: This is a complete clone of #1132 from @williamchong007! Please merge that instead! I'm not trying to take credit, just trying to get this fixed since that PR was auto-closed by the bot despite being a simple and straightforward fix.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

In Typescript, using applicationNameForUserAgent in <WebView> throws a type error

```Property 'applicationNameForUserAgent' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<WebView> & Readonly<WebViewProps> & Readonly<{ children?: ReactNode; }>'.```

This is because #707 moved the type definition from `WebViewSharedProps` to `CommonNativeWebViewProps`. We should define the type in both interfaces.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Tested setting the property. Ran `yarn ci`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
