### PR TITLE
feat(android): Add androidLayerType as prop

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -299,6 +299,21 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
   }
 
+  @ReactProp(name = "androidLayerType")
+  public void setLayerType(WebView view, String layerTypeString) {
+    int layerType = View.LAYER_TYPE_NONE;
+    switch (layerTypeString) {
+        case "hardware":
+          layerType = View.LAYER_TYPE_HARDWARE;
+          break;
+        case "software":
+          layerType = View.LAYER_TYPE_SOFTWARE;
+          break;
+    }
+    view.setLayerType(layerType, null);
+  }
+
+
   @ReactProp(name = "overScrollMode")
   public void setOverScrollMode(WebView view, String overScrollModeString) {
     Integer overScrollMode;

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -35,6 +35,7 @@ This document lays out the current public properties and methods for the React N
 - [`javaScriptEnabled`](Reference.md#javascriptenabled)
 - [`javaScriptCanOpenWindowsAutomatically`](Reference.md#javascriptcanopenwindowsautomatically)
 - [`androidHardwareAccelerationDisabled`](Reference.md#androidHardwareAccelerationDisabled)
+- [`androidLayerType`](Reference.md#androidLayerType)
 - [`mixedContentMode`](Reference.md#mixedcontentmode)
 - [`thirdPartyCookiesEnabled`](Reference.md#thirdpartycookiesenabled)
 - [`userAgent`](Reference.md#useragent)
@@ -781,11 +782,29 @@ A Boolean value indicating whether JavaScript can open windows without user inte
 
 ### `androidHardwareAccelerationDisabled`[⬆](#props-index)<!-- Link generated with jump2header -->
 
-Boolean value to disable Hardware Acceleration in the `WebView`. Used on Android only as Hardware Acceleration is a feature only for Android. The default value is `false`.
+**Deprecated.** Use the `androidLayerType` prop instead. 
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |
 | bool | No       | Android  |
+
+---
+
+### `androidLayerType`[⬆](#props-index)<!-- Link generated with jump2header -->
+
+Specifies the layer type. 
+
+Possible values for `androidLayerType` are:
+
+- `none` (default) - The view does not have a layer.
+- `software` - The view has a software layer. A software layer is backed by a bitmap and causes the view to be rendered using Android's software rendering pipeline, even if hardware acceleration is enabled.
+- `hardware` - The view has a hardware layer. A hardware layer is backed by a hardware specific texture and causes the view to be rendered using Android's hardware rendering pipeline, but only if hardware acceleration is turned on for the view hierarchy.
+
+Avoid setting both `androidLayerType` and `androidHardwareAccelerationDisabled` props at the same time, as this may cause undefined behaviour.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | Android  |
 
 ---
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -61,6 +61,7 @@ class WebView extends React.Component<AndroidWebViewProps, State> {
     saveFormDataDisabled: false,
     cacheEnabled: true,
     androidHardwareAccelerationDisabled: false,
+    androidLayerType: 'none',
     originWhitelist: defaultOriginWhitelist,
   };
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -182,6 +182,8 @@ export type OverScrollModeType = 'always' | 'content' | 'never';
 
 export type CacheMode = 'LOAD_DEFAULT' | 'LOAD_CACHE_ONLY' | 'LOAD_CACHE_ELSE_NETWORK' | 'LOAD_NO_CACHE';
 
+export type AndroidLayerType = 'none' | 'software' | 'hardware';
+
 export interface WebViewSourceUri {
   /**
    * The URI to load in the `WebView`. Can be a local or remote file.
@@ -284,6 +286,7 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   allowFileAccessFromFileURLs?: boolean;
   allowUniversalAccessFromFileURLs?: boolean;
   androidHardwareAccelerationDisabled?: boolean;
+  androidLayerType?: AndroidLayerType;
   domStorageEnabled?: boolean;
   geolocationEnabled?: boolean;
   javaScriptEnabled?: boolean;
@@ -808,6 +811,18 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   androidHardwareAccelerationDisabled?: boolean;
+
+    /**
+   * https://developer.android.com/reference/android/webkit/WebView#setLayerType(int,%20android.graphics.Paint)
+   * Sets the layerType. Possible values are:
+   *
+   * - `'none'` (default)
+   * - `'software'`
+   * - `'hardware'`
+   *
+   * @platform android
+   */
+  androidLayerType?: AndroidLayerType;
 
   /**
    * Boolean value to enable third party cookies in the `WebView`. Used on


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This PR is to add a new React prop, `androidLayerType`, that allows [setting the layer type](https://developer.android.com/reference/android/view/View#setLayerType(int,%20android.graphics.Paint)) for Android using props. It also deprecates `androidHardwareAccelerationDisabled` prop, as the use of both of them at the same time might cause undefined behaviour.

**Motivation:**
The general motivation is to be able to control the layer type through props.
It would also solve the problem of rendering big pieces of HTML in a WebView when the hardware acceleration is disabled.
When we use HA, all drawing operations that are performed on a View's canvas use the GPU, so the layer is set to LAYER_TYPE_HARDWARE. Disabling HA means setting the view to LAYER_TYPE_SOFTWARE, which uses a drawing cache with a specific amount of available memory. If we want to render big pieces of HTML, they might not fit in memory and so they won't be displayed. The problem can be solved by using LAYER_TYPE_NONE, meaning the view is not backed-up by any buffers.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
Tested in my app by linking my fork to it. Worked as expected.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
