### PR TITLE
Fix(types): Update Typescript definition file, declaring WebView class as a generic class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ export { FileDownload, WebViewMessageEvent, WebViewNavigation } from "./lib/WebV
 
 export type WebViewProps = IOSWebViewProps & AndroidWebViewProps;
 
-declare class WebView extends Component<WebViewProps> {
+declare class WebView<P> extends Component<WebViewProps & P> {
     /**
      * Go back one page in the webview's history.
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ export { FileDownload, WebViewMessageEvent, WebViewNavigation } from "./lib/WebV
 
 export type WebViewProps = IOSWebViewProps & AndroidWebViewProps;
 
-declare class WebView<P> extends Component<WebViewProps & P> {
+declare class WebView<P = {}> extends Component<WebViewProps & P> {
     /**
      * Go back one page in the webview's history.
      */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Declare WebView class as a generic class.
Without declaring as a generic class, it will not be possible to do the following (extending WebView with generic):

``` javascript
interface SubWebViewProps extends WebViewProps {}

default class SubWebView extends WebView<SubWebViewProps> {}
```

"Type WebView is not generic." 

## Test Plan

Modified Typescript defination file only.
