### PR TITLE
chore(docs): remove hash url change note

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -541,8 +541,6 @@ title
 url
 ```
 
-Note that this method will not be invoked on hash URL changes (e.g. from `https://example.com/users#list` to `https://example.com/users#help`). There is a workaround for this that is described [in the Guide](Guide.md#intercepting-hash-url-changes).
-
 ---
 
 ### `onContentProcessDidTerminate`[⬆](#props-index)<!-- Link generated with jump2header -->


### PR DESCRIPTION
# Summary

Now that onNavigationStateChange supports hash url changes in 8.x, we should probably remove this footer note to avoid any confusion, since the intercepting hash url changes portion has been removed from the linked guide.

## Test Plan
n/a

### What's required for testing (prerequisites)?
n/a

### What are the steps to reproduce (after prerequisites)?
n/a

## Compatibility
n/a

## Checklist
n/a
