### PR TITLE
Inline C++ operator in RNCWebView.h to avoid duplicate symbols during linking

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 namespace facebook {
 namespace react {
-    bool operator==(const RNCWebViewMenuItemsStruct& a, const RNCWebViewMenuItemsStruct& b)
+    inline bool operator==(const RNCWebViewMenuItemsStruct& a, const RNCWebViewMenuItemsStruct& b)
     {
         return b.key == a.key && b.label == a.label;
     }


### PR DESCRIPTION
Hello,

I'm working on a project where I'm creating a react-native native component that extends RNCWebView. When importing the `RNCWebView.h` header in my project the `==` operator will result in a symbol in my projects cocoapod target product. The same symbol will also be present in react-native-webviews cocoapods product, which causes a linker error like so:

```
ld: warning: ignoring duplicate libraries: '-lc++'
duplicate symbol 'facebook::react::operator==(facebook::react::RNCWebViewMenuItemsStruct const&, facebook::react::RNCWebViewMenuItemsStruct const&)' in:
    /Users/ullrich/Library/Developer/Xcode/DerivedData/Example-geqgqakfnjrqhsbfipgqkrmgbtaw/Build/Products/Debug-iphonesimulator/pitch-mobile-webview/libpitch-mobile-webview.a[3](PitchWebview.o)
    /Users/ullrich/Library/Developer/Xcode/DerivedData/Example-geqgqakfnjrqhsbfipgqkrmgbtaw/Build/Products/Debug-iphonesimulator/react-native-webview/libreact-native-webview.a[4](RNCWebView.o)
ld: 1 duplicate symbols
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

A simple solution to this is to inline this simple function.

Thanks for considering this contribution 🙌