### PR TITLE
Remove hardcoded boolean to avoid pentest report

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -88,9 +88,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.MATCH_PARENT
         )
-        if (ReactBuildConfig.DEBUG) {
-            WebView.setWebContentsDebuggingEnabled(true)
-        }
+        WebView.setWebContentsDebuggingEnabled(ReactBuildConfig.DEBUG)
         webView.setDownloadListener(DownloadListener { url, userAgent, contentDisposition, mimetype, contentLength ->
             val module = webView.reactApplicationContext.getNativeModule(RNCWebViewModule::class.java) ?: return@DownloadListener
             val request: DownloadManager.Request = try {


### PR DESCRIPTION
#### Description
Refactoring of WebView debug configuration on Android to avoid false positives in static code analysis tools.

#### Motivation
Static code analysis tools (such as those used in penetration tests) may flag false positive vulnerabilities when detecting `WebView.setWebContentsDebuggingEnabled(true)`, even when protected by debug conditions.