### PR TITLE
fix decelerationRate property for Android

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -27,11 +27,23 @@ import {
   WebViewSourceUri,
   type WebViewMessageEvent,
   type ShouldStartLoadRequestEvent,
+  DecelerationRateConstant,
 } from './WebViewTypes';
 
 import styles from './WebView.styles';
 
 const { resolveAssetSource } = Image;
+const processDecelerationRate = (
+  decelerationRate: DecelerationRateConstant | number | undefined
+) => {
+  let newDecelerationRate = decelerationRate;
+  if (newDecelerationRate === 'normal') {
+    newDecelerationRate = 0.985;
+  } else if (newDecelerationRate === 'fast') {
+    newDecelerationRate = 0.9;
+  }
+  return newDecelerationRate;
+};
 
 const directEventEmitter = new EventEmitter();
 
@@ -94,6 +106,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(
       containerStyle,
       source,
       nativeConfig,
+      decelerationRate: decelerationRateProp,
       onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
       injectedJavaScriptObject,
       ...otherProps
@@ -239,6 +252,8 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(
     const webViewStyles = [styles.container, styles.webView, style];
     const webViewContainerStyle = [styles.container, containerStyle];
 
+    const decelerationRate = processDecelerationRate(decelerationRateProp);
+
     if (typeof source !== 'number' && source && 'method' in source) {
       if (source.method === 'POST' && source.headers) {
         console.warn(
@@ -280,6 +295,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(
       <NativeWebView
         key="webViewKey"
         {...otherProps}
+        decelerationRate={decelerationRate}
         messagingEnabled={typeof onMessageProp === 'function'}
         messagingModuleName={messagingModuleName}
         hasOnScroll={!!otherProps.onScroll}

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -978,6 +978,15 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
   cacheMode?: CacheMode;
 
   /**
+   * A floating-point number that determines how quickly the scroll view
+   * decelerates after the user lifts their finger.
+   *   - normal: 0.985 (the default for Android web view)
+   *   - fast: 0.9
+   * @platform android
+   */
+  decelerationRate?: DecelerationRateConstant | number;
+
+  /**
    * https://developer.android.com/reference/android/view/View#setOverScrollMode(int)
    * Sets the overScrollMode. Possible values are:
    *


### PR DESCRIPTION
Fixes an issue where setting `decelerationRate` on Android fails because the property passes as a string and not a float. The underlying `RNCWebViewManager.java` accepts this property but it's not transformed in the Android React component.

```typescript
public void setDecelerationRate(RNCWebViewWrapper view, double value) {}
```

See https://github.com/react-native-webview/react-native-webview/issues/3814