### PR TITLE
feat(android): add hasGesture in onShouldStartLoadRequest event

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -90,8 +90,7 @@ public class RNCWebViewClient extends WebViewClient {
       reactWebView.callInjectedJavaScriptBeforeContentLoaded();
     }
 
-    @Override
-    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+    private boolean mShouldOverrideUrlLoading(WebView view, String url, @Nullable WebResourceRequest request) {
         final RNCWebView rncWebView = (RNCWebView) view;
         final boolean isJsDebugging = rncWebView.getReactApplicationContext().getJavaScriptContextHolder().get() == 0;
 
@@ -102,6 +101,11 @@ public class RNCWebViewClient extends WebViewClient {
 
             final WritableMap event = createWebViewEvent(view, url);
             event.putDouble("lockIdentifier", lockIdentifier);
+
+            if (request != null) {
+                event.putBoolean("hasGesture", request.hasGesture());
+            }
+
             rncWebView.dispatchDirectShouldStartLoadWithRequest(event);
 
             try {
@@ -139,11 +143,16 @@ public class RNCWebViewClient extends WebViewClient {
         }
     }
 
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        return this.mShouldOverrideUrlLoading(view, url, null);
+    }
+
     @TargetApi(Build.VERSION_CODES.N)
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
         final String url = request.getUrl().toString();
-        return this.shouldOverrideUrlLoading(view, url);
+        return this.mShouldOverrideUrlLoading(view, url, request);
     }
 
     @Override

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -830,9 +830,12 @@ mainDocumentURL (iOS only)
 navigationType (iOS only)
 isTopFrame (iOS only)
 hasTargetFrame (iOS only)
+hasGesture (Android only)
 ```
 
 The `hasTargetFrame` prop is a boolean that is `false` when the navigation targets a new window or tab, otherwise it should be `true` ([more info](https://developer.apple.com/documentation/webkit/wknavigationaction/1401918-targetframe)). Note that this prop should always be `true` when `onOpenWindow` event is registered on the WebView because the `false` case is intercepted by this event.
+
+The `hasGesture` prop is a boolean that is an equivalent of `navigationType: 'click'`. See the [Android documentation](https://developer.android.com/reference/android/webkit/WebResourceRequest#hasGesture()).
 
 ---
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -100,6 +100,12 @@ export interface WebViewNavigation extends WebViewNativeEvent {
 
 export interface ShouldStartLoadRequest extends WebViewNavigation {
   isTopFrame: boolean;
+  /**
+   * Equivalent to `navigationType: 'click'`
+   *
+   * @platform android
+   */
+  hasGesture?: boolean;
 }
 
 export interface FileDownload {


### PR DESCRIPTION
This feature adds back the `hasGesture` boolean in the `onShouldStartLoadWithRequest` event for Android that was added in https://github.com/react-native-webview/react-native-webview/pull/1881 but seemed to have been removed.