### PR TITLE
  [iOS] Extract filename from Content-Disposition header

### DIFF
--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -407,7 +407,8 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                 if (_eventEmitter) {
                     auto webViewEventEmitter = std::static_pointer_cast<RNCWebViewEventEmitter const>(_eventEmitter);
                     facebook::react::RNCWebViewEventEmitter::OnFileDownload data = {
-                        .downloadUrl = std::string([[dictionary valueForKey:@"downloadUrl"] UTF8String])
+                        .downloadUrl = std::string([[dictionary valueForKey:@"downloadUrl"] UTF8String]),
+                        .filename = std::string([[dictionary valueForKey:@"filename"] UTF8String])
                     };
                     webViewEventEmitter->onFileDownload(data);
                 }

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1469,6 +1469,16 @@ RCTAutoInsetsProtocol>
         [downloadEvent addEntriesFromDictionary: @{
           @"downloadUrl": (response.URL).absoluteString,
         }];
+        NSRange fnRange = [disposition rangeOfString:@"filename="];
+        if (fnRange.location != NSNotFound) {
+          // case where header value is like `Content-Disposition: attachment; filename="my-file.pdf"`
+          fnRange.location = fnRange.location + 10;
+          fnRange.length = disposition.length - 1 - fnRange.location;
+          NSString *filename = [disposition substringWithRange: fnRange];
+          [downloadEvent addEntriesFromDictionary: @{
+            @"filename": filename,
+          }];
+        }
         _onFileDownload(downloadEvent);
       }
     }

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -138,6 +138,7 @@ type WebViewRenderProcessGoneEvent = Readonly<{
 
 type WebViewDownloadEvent = Readonly<{
   downloadUrl: string;
+  filename?: string;
 }>;
 
 // type MenuItem = Readonly<{label: string, key: string}>;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -104,6 +104,7 @@ export interface ShouldStartLoadRequest extends WebViewNavigation {
 
 export interface FileDownload {
   downloadUrl: string;
+  filename?: string;
 }
 
 export type DecelerationRateConstant = 'normal' | 'fast';


### PR DESCRIPTION
Reopen PR from @zabojad

…and expose it to onFileDownload callback.

This PR aims to solve issue https://github.com/react-native-webview/react-native-webview/issues/3600 (closed) and https://github.com/react-native-webview/react-native-webview/issues/3897