### PR TITLE
feat(android): add client certificate (mTLS) support via Android KeyChain

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -219,6 +219,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
     public void setWebViewClient(WebViewClient client) {
         super.setWebViewClient(client);
         if (client instanceof RNCWebViewClient) {
+            ((RNCWebViewClient) client).setReactContext(this.getReactApplicationContext()); // WV 13.16.0 PATCH
             mRNCWebViewClient = (RNCWebViewClient) client;
             mRNCWebViewClient.setProgressChangedFilter(progressChangedFilter);
         }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModuleImpl.java
@@ -60,6 +60,11 @@ public class RNCWebViewModuleImpl implements ActivityEventListener {
     private File mOutputImage;
     private File mOutputVideo;
 
+    // WV PATCHES 13.16.0
+    public static void setCertificateAlias(String alias) {
+        RNCWebViewClient.setCertificateAlias(alias);
+    }
+
     public RNCWebViewModuleImpl(ReactApplicationContext context) {
         mContext = context;
         context.addActivityEventListener(this);

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -40,6 +40,11 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     private final ViewManagerDelegate<RNCWebViewWrapper> mDelegate;
     private final RNCWebViewManagerImpl mRNCWebViewManagerImpl;
 
+    // WV PATCHES 13.16.0
+    public static void setCertificateAlias(String alias) {
+        RNCWebViewModule.setCertificateAlias(alias);
+    }
+
     public RNCWebViewManager() {
         mDelegate = new RNCWebViewManagerDelegate<>(this);
         mRNCWebViewManagerImpl = new RNCWebViewManagerImpl(true);

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -14,6 +14,11 @@ import com.facebook.react.module.annotations.ReactModule;
 public class RNCWebViewModule extends NativeRNCWebViewModuleSpec {
     final private RNCWebViewModuleImpl mRNCWebViewModuleImpl;
 
+    // WV PATCHES 13.16.0
+    public static void setCertificateAlias(String alias) {
+        RNCWebViewModuleImpl.setCertificateAlias(alias);
+    }
+
     public RNCWebViewModule(ReactApplicationContext reactContext) {
         super(reactContext);
         mRNCWebViewModuleImpl = new RNCWebViewModuleImpl(reactContext);

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -32,6 +32,11 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
         mRNCWebViewManagerImpl = new RNCWebViewManagerImpl();
     }
 
+    // WV PATCHES 13.16.0
+    public static void setCertificateAlias(String alias) {
+        RNCWebViewModule.setCertificateAlias(alias);
+    }
+
     @Override
     public String getName() {
         return RNCWebViewManagerImpl.NAME;

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -20,6 +20,11 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule {
         super(reactContext);
         mRNCWebViewModuleImpl = new RNCWebViewModuleImpl(reactContext);
     }
+    
+    // WV PATCHES 13.16.0
+    public static void setCertificateAlias(String alias) {
+        RNCWebViewModuleImpl.setCertificateAlias(alias);
+    }
 
     @ReactMethod
     public void isFileUploadSupported(final Promise promise) {


### PR DESCRIPTION
This PR adds support for Android WebView client certificate authentication (mTLS).

When a server requests a client certificate, the WebView can retrieve a private key
and certificate chain from Android KeyChain using a provided alias and proceed
with the request.

Key points:
- Uses Android KeyChain APIs
- Supports both old and new React Native architectures
- No behavior change unless explicitly enabled
- Backwards compatible

This is required for environments using mutual TLS authentication.
