### PR TITLE
Implement scrollsToTop prop (IOS)

### DIFF
--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -429,9 +429,6 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     @Override
     public void setFraudulentWebsiteWarningEnabled(RNCWebViewWrapper view, boolean value) {}
 
-    @Override
-    public void setDragInteractionEnabled(RNCWebViewWrapper view, boolean value) {}
-
 	@Override
     public void setScrollsToTop(RNCWebViewWrapper view, boolean value) {}
 

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -429,7 +429,7 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     @Override
     public void setFraudulentWebsiteWarningEnabled(RNCWebViewWrapper view, boolean value) {}
 
-	@Override
+    @Override
     public void setScrollsToTop(RNCWebViewWrapper view, boolean value) {}
 
 	/* !iOS PROPS - no implemented here */

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -428,8 +428,14 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     @Override
     public void setFraudulentWebsiteWarningEnabled(RNCWebViewWrapper view, boolean value) {}
-    /* !iOS PROPS - no implemented here */
 
+    @Override
+    public void setDragInteractionEnabled(RNCWebViewWrapper view, boolean value) {}
+
+	@Override
+    public void setScrollsToTop(RNCWebViewWrapper view, boolean value) {}
+
+	/* !iOS PROPS - no implemented here */
     @Override
     @ReactProp(name = "userAgent")
     public void setUserAgent(RNCWebViewWrapper view, @Nullable String value) {

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -313,7 +313,6 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
     REMAP_WEBVIEW_PROP(showsVerticalScrollIndicator)
     REMAP_WEBVIEW_PROP(keyboardDisplayRequiresUserAction)
     REMAP_WEBVIEW_PROP(scrollsToTop)
-    REMAP_WEBVIEW_PROP(dragInteractionEnabled)
 	
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
     REMAP_WEBVIEW_PROP(automaticallyAdjustContentInsets)

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -312,7 +312,9 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
     REMAP_WEBVIEW_PROP(showsHorizontalScrollIndicator)
     REMAP_WEBVIEW_PROP(showsVerticalScrollIndicator)
     REMAP_WEBVIEW_PROP(keyboardDisplayRequiresUserAction)
-
+    REMAP_WEBVIEW_PROP(scrollsToTop)
+    REMAP_WEBVIEW_PROP(dragInteractionEnabled)
+	
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
     REMAP_WEBVIEW_PROP(automaticallyAdjustContentInsets)
 #endif

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -104,6 +104,8 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL showsVerticalScrollIndicator;
 @property (nonatomic, copy) NSString * _Nullable indicatorStyle;
 @property (nonatomic, assign) BOOL directionalLockEnabled;
+@property (nonatomic, assign) BOOL scrollsToTop;
+@property (nonatomic, assign) BOOL dragInteractionEnabled;
 @property (nonatomic, assign) BOOL ignoreSilentHardwareSwitch;
 @property (nonatomic, copy) NSString * _Nullable allowingReadAccessToURL;
 @property (nonatomic, copy) NSDictionary * _Nullable basicAuthCredential;

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -105,7 +105,6 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, copy) NSString * _Nullable indicatorStyle;
 @property (nonatomic, assign) BOOL directionalLockEnabled;
 @property (nonatomic, assign) BOOL scrollsToTop;
-@property (nonatomic, assign) BOOL dragInteractionEnabled;
 @property (nonatomic, assign) BOOL ignoreSilentHardwareSwitch;
 @property (nonatomic, copy) NSString * _Nullable allowingReadAccessToURL;
 @property (nonatomic, copy) NSDictionary * _Nullable basicAuthCredential;

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -169,6 +169,8 @@ RCTAutoInsetsProtocol>
     _allowsLinkPreview = YES;
     _showsVerticalScrollIndicator = YES;
     _directionalLockEnabled = YES;
+    _scrollsToTop = YES;
+    _dragInteractionEnabled = YES;
     _useSharedProcessPool = YES;
     _cacheEnabled = YES;
     _mediaPlaybackRequiresUserAction = YES;
@@ -545,6 +547,7 @@ RCTAutoInsetsProtocol>
     }
 
     _webView.scrollView.directionalLockEnabled = _directionalLockEnabled;
+    _webView.scrollView.scrollsToTop = _scrollsToTop;
 #endif // !TARGET_OS_OSX
     _webView.allowsLinkPreview = _allowsLinkPreview;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
@@ -1104,6 +1107,22 @@ RCTAutoInsetsProtocol>
     _webView.scrollView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
   } else {
     _webView.scrollView.indicatorStyle = UIScrollViewIndicatorStyleDefault;
+  }
+}
+
+- (void)setScrollsToTop:(BOOL)scrollsToTop
+{
+  _scrollsToTop = scrollsToTop;
+  _webView.scrollView.scrollsToTop = scrollsToTop;
+}
+
+- (void)setDragInteractionEnabled:(BOOL)dragInteractionEnabled
+{
+  _dragInteractionEnabled = dragInteractionEnabled;
+  for (id<UIInteraction> interaction in _webView.scrollView.interactions) {
+    if ([interaction isKindOfClass:[UIDragInteraction class]]) {
+      ((UIDragInteraction *)interaction).enabled = dragInteractionEnabled;
+    }
   }
 }
 #endif // !TARGET_OS_OSX

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -170,7 +170,6 @@ RCTAutoInsetsProtocol>
     _showsVerticalScrollIndicator = YES;
     _directionalLockEnabled = YES;
     _scrollsToTop = YES;
-    _dragInteractionEnabled = YES;
     _useSharedProcessPool = YES;
     _cacheEnabled = YES;
     _mediaPlaybackRequiresUserAction = YES;
@@ -1116,15 +1115,6 @@ RCTAutoInsetsProtocol>
   _webView.scrollView.scrollsToTop = scrollsToTop;
 }
 
-- (void)setDragInteractionEnabled:(BOOL)dragInteractionEnabled
-{
-  _dragInteractionEnabled = dragInteractionEnabled;
-  for (id<UIInteraction> interaction in _webView.scrollView.interactions) {
-    if ([interaction isKindOfClass:[UIDragInteraction class]]) {
-      ((UIDragInteraction *)interaction).enabled = dragInteractionEnabled;
-    }
-  }
-}
 #endif // !TARGET_OS_OSX
 
 - (void)postMessage:(NSString *)message

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -179,10 +179,6 @@ RCT_CUSTOM_VIEW_PROPERTY(scrollsToTop, BOOL, RNCWebViewImpl) {
   view.scrollsToTop = json == nil ? true : [RCTConvert BOOL: json];
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(dragInteractionEnabled, BOOL, RNCWebViewImpl) {
-  view.dragInteractionEnabled = json == nil ? true : [RCTConvert BOOL: json];
-}
-
 #if !TARGET_OS_OSX
     #define BASE_VIEW_PER_OS() UIView
 #else

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -175,6 +175,14 @@ RCT_CUSTOM_VIEW_PROPERTY(keyboardDisplayRequiresUserAction, BOOL, RNCWebViewImpl
   view.keyboardDisplayRequiresUserAction = json == nil ? true : [RCTConvert BOOL: json];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(scrollsToTop, BOOL, RNCWebViewImpl) {
+  view.scrollsToTop = json == nil ? true : [RCTConvert BOOL: json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(dragInteractionEnabled, BOOL, RNCWebViewImpl) {
+  view.dragInteractionEnabled = json == nil ? true : [RCTConvert BOOL: json];
+}
+
 #if !TARGET_OS_OSX
     #define BASE_VIEW_PER_OS() UIView
 #else

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -236,7 +236,6 @@ export interface NativeProps extends ViewProps {
   scrollEnabled?: WithDefault<boolean, true>;
   scrollsToTop?: WithDefault<boolean, true>;
   sharedCookiesEnabled?: boolean;
-  dragInteractionEnabled?: WithDefault<boolean, true>;
   textInteractionEnabled?: WithDefault<boolean, true>;
   useSharedProcessPool?: WithDefault<boolean, true>;
   onContentProcessDidTerminate?: DirectEventHandler<WebViewNativeEvent>;

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -234,7 +234,9 @@ export interface NativeProps extends ViewProps {
   pullToRefreshEnabled?: boolean;
   refreshControlLightMode?: boolean;
   scrollEnabled?: WithDefault<boolean, true>;
+  scrollsToTop?: WithDefault<boolean, true>;
   sharedCookiesEnabled?: boolean;
+  dragInteractionEnabled?: WithDefault<boolean, true>;
   textInteractionEnabled?: WithDefault<boolean, true>;
   useSharedProcessPool?: WithDefault<boolean, true>;
   onContentProcessDidTerminate?: DirectEventHandler<WebViewNativeEvent>;

--- a/src/WebView.tsx
+++ b/src/WebView.tsx
@@ -7,7 +7,6 @@ import {
 } from './WebViewTypes';
 import styles from './WebView.styles';
 
-alert("kek");
 
 export type WebViewProps = IOSWebViewProps &
   AndroidWebViewProps &

--- a/src/WebView.tsx
+++ b/src/WebView.tsx
@@ -7,7 +7,6 @@ import {
 } from './WebViewTypes';
 import styles from './WebView.styles';
 
-
 export type WebViewProps = IOSWebViewProps &
   AndroidWebViewProps &
   WindowsWebViewProps;

--- a/src/WebView.tsx
+++ b/src/WebView.tsx
@@ -7,6 +7,8 @@ import {
 } from './WebViewTypes';
 import styles from './WebView.styles';
 
+alert("kek");
+
 export type WebViewProps = IOSWebViewProps &
   AndroidWebViewProps &
   WindowsWebViewProps;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -777,6 +777,21 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   fraudulentWebsiteWarningEnabled?: boolean;
+
+  /**
+   * If the value of this property is true (the default), the scroll view scrolls to
+   * top when the user taps the status bar. If false, the scroll view does not scroll to top.
+   * @platform ios
+   */
+  scrollsToTop?: boolean;
+
+  /**
+   * A Boolean value indicating whether the web view supports drag interactions.
+   * The default value is `true`.
+   * @platform ios
+   */
+  dragInteractionEnabled?: boolean;
+
 }
 
 export interface MacOSWebViewProps extends WebViewSharedProps {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -784,7 +784,6 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   scrollsToTop?: boolean;
-
 }
 
 export interface MacOSWebViewProps extends WebViewSharedProps {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -779,18 +779,11 @@ export interface IOSWebViewProps extends WebViewSharedProps {
   fraudulentWebsiteWarningEnabled?: boolean;
 
   /**
-   * If the value of this property is true (the default), the scroll view scrolls to
-   * top when the user taps the status bar. If false, the scroll view does not scroll to top.
-   * @platform ios
-   */
-  scrollsToTop?: boolean;
-
-  /**
-   * A Boolean value indicating whether the web view supports drag interactions.
+   * A Boolean value which determines whether the WebView scrolls to top if user taps on the status bar.
    * The default value is `true`.
    * @platform ios
    */
-  dragInteractionEnabled?: boolean;
+  scrollsToTop?: boolean;
 
 }
 


### PR DESCRIPTION
**What**
Adds scrollsToTop prop.
When set to false, prevents the WebView from automatically scrolling to the top, when the user taps the iOS statusbar.

**Why?**
This has become a necessary option since iOS 26 has increased the height of the touch target of the status bar.
Buttons in the top of apps, even those respecting safe area, can accidently trigger the scrollToTop functionality.
Thus, a need arose to disable it on the WebView.

**Credit**
Based on https://github.com/react-native-webview/react-native-webview/pull/3919 by [artemlitch](https://github.com/artemlitch)