### PR TITLE
docs: clarify React Native to Web postMessage usage via WebView ref

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1797,7 +1797,14 @@ Request the webView to ask for focus. (People working on TV apps might want havi
 postMessage('message');
 ```
 
-Post a message to WebView, handled by [`onMessage`](Reference.md#onmessage).
+Posts a message from React Native to the WebView.
+
+The message can be received inside the WebView by listening to the `'message'` event:
+
+- `window.addEventListener('message', handler)` (iOS)
+- `document.addEventListener('message', handler)` (Android)
+
+To learn more, read the **PostMessage** section of the guide: [Communicating between JS and Native](Guide.md#the-postmessage-method-on-the-webview-ref).
 
 ### `clearFormData()`[⬆](#methods-index)
 


### PR DESCRIPTION
### What
Adds documentation for the `postMessage` method available on the WebView ref.

This documents how to use `webViewRef.current.postMessage(...)` to send messages from React Native to the WebView, and how to properly listen for the resulting `'message'` event (`window` vs `document`).

### Why
The React Native → Web `postMessage` API was not clearly documented, which led to confusion about how messages are delivered and how they should be handled inside the WebView, especially regarding the event target (`window` or `document`).

This clarification addresses questions raised in #3776.